### PR TITLE
Publish Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+on:
+  push:
+    branches:
+      - 'main'
+      - 'master'
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: "0.81.0"
+
+      - name: Build Hugo Site
+        run: hugo --minify
+
+      - name: Deploy GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.PUBLISH_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages
+          cname: rotational.io

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -21,6 +21,9 @@ rm -rf public/*
 echo "Generating site"
 hugo
 
+echo "Recreating CNAME"
+cp CNAME public/
+
 echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
 

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -19,7 +19,7 @@ echo "Removing existing files"
 rm -rf public/*
 
 echo "Generating site"
-hugo
+hugo --minify
 
 echo "Recreating CNAME"
 cp CNAME public/


### PR DESCRIPTION
This PR fixes the manual `bin/publish.sh` script by copying the CNAME from the root of the repository into the gh-pages branch. It also minifies the CSS and JS (due to concerns about page load time). The PR also adds a GitHub actions configuration so that the site is published automatically on push to the master or main branches. 