### PR TITLE
Sets canonical URLs and permalinks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,10 @@ disqusShortname = ""    # get your shortname form here : https://disqus.com
 # Disable any languages from build process
 disableLanguages = []
 
+# Set canonical URLs
+[permalinks]
+  blog = "/blog/:slug/"
+
 ## Default Parameters
 [params]
 # Metadata

--- a/content/en/blog/2016-04-26-visualizing-distributed-systems.md
+++ b/content/en/blog/2016-04-26-visualizing-distributed-systems.md
@@ -1,5 +1,6 @@
 ---
 title: "Visualizing Distributed Systems"
+slug: "visualizing-distributed-systems"
 date: 2016-04-26T11:34:42Z
 image_webp: images/blog/savanah_c.webp
 image: images/blog/savanah_c.jpg

--- a/content/en/blog/2017-02-21-synchronizing-structs.md
+++ b/content/en/blog/2017-02-21-synchronizing-structs.md
@@ -1,5 +1,6 @@
 ---
 title: "Synchronizing Structs for Safe Concurrency in Go"
+slug: "synchronizing-structs"
 date: 2017-02-21T10:48:24Z
 image_webp: images/blog/lake_c.webp
 image: images/blog/lake_c.jpg

--- a/content/en/blog/2017-09-04-message-throughput.md
+++ b/content/en/blog/2017-09-04-message-throughput.md
@@ -1,5 +1,6 @@
 ---
 title: "Messaging Throughput gRPC vs. ZMQ"
+slug: "message-throughput-grpc-vs-zmq"
 date: 2017-09-04T17:20:06Z
 image_webp: images/blog/jungle_c.webp
 image: images/blog/jungle_c.jpg

--- a/content/en/blog/2018-08-03-actor-model.md
+++ b/content/en/blog/2018-08-03-actor-model.md
@@ -1,5 +1,6 @@
 ---
 title: "The Actor Model"
+slug: "actor-model"
 date: 2018-08-03T07:27:36Z
 image_webp: images/blog/leaf.webp
 image: images/blog/leaf.jpg

--- a/content/en/blog/2018-09-11-streaming-remote-throughput.md
+++ b/content/en/blog/2018-09-11-streaming-remote-throughput.md
@@ -1,5 +1,6 @@
 ---
 title: "Streaming Remote Throughput"
+slug: "streaming-remote-throughput"
 date: 2018-09-11T15:19:17Z
 image_webp: images/blog/mountain_c.webp
 image: images/blog/mountain_c.jpg

--- a/content/en/blog/2018-09-22-go-testing-notes.md
+++ b/content/en/blog/2018-09-22-go-testing-notes.md
@@ -1,5 +1,6 @@
 ---
 title: "Go Testing Notes"
+slug: "go-testing-notes"
 date: 2018-09-22T09:58:12Z
 image_webp: images/blog/lake2_c.webp
 image: images/blog/lake2_c.jpg

--- a/content/en/blog/2018-12-02-laissez-faire-systems.md
+++ b/content/en/blog/2018-12-02-laissez-faire-systems.md
@@ -1,5 +1,6 @@
 ---
 title: "Laissez-Faire in Distributed Systems"
+slug: "laissez-faire-distributed-systems"
 date: 2018-12-02T16:42:00Z
 image_webp: images/blog/forest_c.webp
 image: images/blog/forest_c.jpg

--- a/content/en/blog/2019-02-08-pop-dist-sys.md
+++ b/content/en/blog/2019-02-08-pop-dist-sys.md
@@ -1,5 +1,6 @@
 ---
 title: "Pop Distributed Systems"
+slug: "pop-distributed-systems"
 date: 2019-02-08T10:07:00Z
 image_webp: images/blog/beach_c.webp
 image: images/blog/beach_c.jpg

--- a/content/en/blog/2019-03-02-georeplication-bakeoff.md
+++ b/content/en/blog/2019-03-02-georeplication-bakeoff.md
@@ -1,5 +1,6 @@
 ---
 title: "The Georeplication Bakeoff"
+slug: "georeplication-bakeoff"
 date: 2019-03-02T14:59:00Z
 image_webp: images/blog/outback_c.webp
 image: images/blog/outback_c.jpg

--- a/content/en/blog/2020-07-14-basic-python-profiling.md
+++ b/content/en/blog/2020-07-14-basic-python-profiling.md
@@ -1,5 +1,6 @@
 ---
 title: "Basic Python Profiling"
+slug: "basic-python-profiling"
 date: 2020-07-14T18:01:08Z
 image_webp: images/blog/sunrise_c.webp
 image: images/blog/sunrise_c.jpg

--- a/content/en/blog/2020-07-19-ux-whats-missing.md
+++ b/content/en/blog/2020-07-19-ux-whats-missing.md
@@ -1,5 +1,6 @@
 ---
 title: "Why UX Will Get Worse Before it Gets Better"
+slug: "ux-whats-missing"
 date: 2020-07-19T15:46:00Z
 image_webp: images/blog/window.webp
 image: images/blog/window.jpg

--- a/content/en/blog/2021-01-21-grpc-openapi-docs.md
+++ b/content/en/blog/2021-01-21-grpc-openapi-docs.md
@@ -1,5 +1,6 @@
 ---
 title: "Documenting a gRPC API with OpenAPI"
+slug: "documenting-grpc-with-openapi"
 date: 2021-01-21T17:45:35Z
 image_webp: images/blog/gateway.webp
 image: images/blog/gateway.jpg

--- a/content/en/blog/2021-03-19-a-parrot-trainer-eats-crow.md
+++ b/content/en/blog/2021-03-19-a-parrot-trainer-eats-crow.md
@@ -1,6 +1,6 @@
 ---
 title: "A Parrot Trainer Eats Crow"
-slug: "2021-03-19-a-parrot-trainer-eats-crow"
+slug: "a-parrot-trainer-eats-crow"
 date: "2021-03-19T08:42:21-04:00"
 draft: false
 image_webp: images/blog/parrots.webp


### PR DESCRIPTION
Recommended short permalink of just /blog/:slug/ - no need for
uniqueness features such as a hash, date or author; we'll ensure
uniqueness by managing slugs directly. Focus on shorter URLs for easier
sharing and URL recognition.