### PR TITLE
fixed footer links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -200,7 +200,7 @@ link = "https://twitter.com/rotationalio"
 
 [[params.social]]
 icon = "ti-github"
-link = "https://github.com/rotational.io"
+link = "https://github.com/rotationalio"
 
 [[params.social]]
 icon = "ti-linkedin"

--- a/data/en/contact.yml
+++ b/data/en/contact.yml
@@ -8,13 +8,13 @@ contact:
   # Themify icon pack : https://themify.me/themify-icons
   contact_list:
     - icon : ti-email
-      info : "info@rotational.io"
+      info1 : "info@rotational.io"
     - icon : ti-twitter
-      info : "@rotationalio"
+      info2 : "@rotationalio"
     - icon : ti-github
-      info : "rotationalio"
+      info3 : "rotationalio"
     - icon : ti-linkedin
-      info : rotational
+      info4 : rotational
 
   # # Contact form
   # # Works with https://formspree.io

--- a/data/fr/contact.yml
+++ b/data/fr/contact.yml
@@ -9,13 +9,13 @@ contact:
   # Themify icon pack : https://themify.me/themify-icons
   contact_list:
     - icon : ti-email
-      info : "info@rotational.io"
+      info1 : "info@rotational.io"
     - icon : ti-twitter
-      info : "@rotationalio"
+      info2 : "@rotationalio"
     - icon : ti-github
-      info : "rotationalio"
+      info3 : "rotationalio"
     - icon : ti-linkedin
-      info : rotational
+      info4 : rotational
 
   # # Contact form
   # # Works with https://formspree.io

--- a/data/zh/contact.yml
+++ b/data/zh/contact.yml
@@ -9,13 +9,13 @@ contact:
   # Themify icon pack : https://themify.me/themify-icons
   contact_list:
     - icon : ti-email
-      info : "info@rotational.io"
+      info1 : "info@rotational.io"
     - icon : ti-twitter
-      info : "@rotationalio"
+      info2 : "@rotationalio"
     - icon : ti-github
-      info : "rotationalio"
+      info3 : "rotationalio"
     - icon : ti-linkedin
-      info : rotational
+      info4 : rotational
 
   # # Contact form
   # # Works with https://formspree.io

--- a/themes/meghna-hugo/layouts/partials/contact.html
+++ b/themes/meghna-hugo/layouts/partials/contact.html
@@ -62,7 +62,10 @@
 				{{ range .contact_list }}
 				<div class="con-info clearfix">
 					<i class="{{ .icon }}"></i>
-					<span>{{ .info }}</span>
+					<span style="color:#57cbcc">{{ .info1 }}</span>
+					<span><a href="https://twitter.com/rotationalio" target="_blank">{{ .info2 }}</a></span>
+					<span><a href="https://github.com/rotationalio" target="_blank">{{ .info3 }}</a></span>
+					<span><a href="https://www.linkedin.com/company/rotational/" target="_blank">{{ .info4 }}</a></span>
 				</div>
 				{{ end }}
 			</div>


### PR DESCRIPTION
Replaced broken github link at contact footer icon 
and linked contact section's icons with text to the link they each belongs