### PR TITLE
Upgrade ubuntu in ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We currently have an error in our CI run:

```bash
[Publish: .github#L1](https://github.com/rotationalio/rotational.io/pull/84/files#annotation_5013564650)
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```

This PR updates the ubuntu version to use whatever the latest is, in the hopes that this covers us indefinitely.