### PR TITLE
Removed photo credits from about this post

### DIFF
--- a/content/en/blog/2021-01-21-hello-world.md
+++ b/content/en/blog/2021-01-21-hello-world.md
@@ -6,7 +6,6 @@ draft: false
 image: img/blog/2021-01-21-hello-world/gulfatnight.jpg
 author: Benjamin Bengfort
 category: "Distributed Systems"
-photo_credit: NASA
 description: "Hello World! We're Rotational Labs."
 profile: img/team/benjamin-bengfort.png
 ---
@@ -25,5 +24,4 @@ Hello, world &mdash; we can’t wait to work with you!
 
 ---
 
-<!-- Photo by [NASA](https://www.nasa.gov/content/the-us-gulf-coast-at-night).
- -->
+Photo by [NASA](https://www.nasa.gov/content/the-us-gulf-coast-at-night).

--- a/content/en/blog/2021-07-06-cloud-generations.md
+++ b/content/en/blog/2021-07-06-cloud-generations.md
@@ -6,7 +6,6 @@ draft: false
 image: img/blog/2021-07-06-cloud-generations/cloudgeneration.jpg
 author: Edwin Schmierer
 category: Cloud, Technology
-photo_credit: Ferdinand Stöhr via Unsplash
 description: "How the public cloud has evolved and where it is headed"
 profile: img/team/edwin-schmierer.png
 ---
@@ -80,4 +79,4 @@ The bottom line is that scale still matters, but it's not enough &mdash; because
 
 ---
 
-<!-- Photo by [Ferdinand Stöhr](https://unsplash.com/@fellowferdi?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/driving-into-a-cloud?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText). -->
+Photo by [Ferdinand Stöhr](https://unsplash.com/@fellowferdi?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/driving-into-a-cloud?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText).

--- a/content/en/blog/2021-08-30-data-privacy-laws.md
+++ b/content/en/blog/2021-08-30-data-privacy-laws.md
@@ -6,7 +6,6 @@ draft: false
 image: img/blog/islands.jpg
 author: Edwin Schmierer
 category: "Data Privacy"
-photo_credit: Irina Shishkina via Unsplash
 description: "We look at the state of play in data privacy regulations and how business and tech leaders can adapt."
 profile: img/team/edwin-schmierer.png
 
@@ -53,4 +52,4 @@ In contrast, business and tech leaders should adopt a core philosophy that [prio
 
 ---
 
-<!-- Photo by <a href="https://unsplash.com/@whoisrobinhood?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Irina Shishkina</a> on <a href="https://unsplash.com/s/photos/privacy-nature?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a> -->
+Photo by [Irina Shishkina](https://unsplash.com/@whoisrobinhood?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/privacy-nature?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)

--- a/content/en/blog/2021-10-01-introducing-whisper.md
+++ b/content/en/blog/2021-10-01-introducing-whisper.md
@@ -6,7 +6,6 @@ draft: false
 image: img/blog/whispering_wheat.jpg
 author: Edwin Schmierer
 category: Security
-photo_credit: Kent Pilcher via Unsplash
 description: "Shhh..there's a better way to share secrets. Introducing Whisper, our secret-sharing utility."
 profile: img/team/edwin-schmierer.png
 ---
@@ -29,4 +28,4 @@ Stay tuned for an upcoming post about the technical details under the hood. For 
 
 ---
 
-<!-- Photo by <a href="https://unsplash.com/@kent_pilcher?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Kent Pilcher</a> on <a href="https://unsplash.com/s/photos/wind-blowing-on-wheat?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a> -->
+Photo by [Kent Pilcher](https://unsplash.com/@kent_pilcher?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/wind-blowing-on-wheat?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)

--- a/content/en/blog/2021-10-22-why-devs-dont-translate.md
+++ b/content/en/blog/2021-10-22-why-devs-dont-translate.md
@@ -6,7 +6,6 @@ draft: false
 image: img/blog/hubble_tarantula_nebula.jpg
 author: Rebecca Bilbro
 category: i18n
-photo_credit: Judy Schmidt via Flickr
 description: "Many tech projects do not translate their docs, often at the expense of reaching a more global userbase. In this post we explore why."
 profile: img/team/rebecca-bilbro.png
 ---
@@ -74,4 +73,4 @@ Do you have a project that puts i18n and l10n first? Are you working on an Inter
 
 ---
 
-<!-- [Photo](https://flic.kr/p/Yaz1mM) by Judy Schmidt on Flickr, CC By 2.0 -->
+[Photo](https://flic.kr/p/Yaz1mM) by Judy Schmidt on Flickr, CC By 2.0

--- a/content/en/blog/2021-12-06-fake-it-when-you-make-it.md
+++ b/content/en/blog/2021-12-06-fake-it-when-you-make-it.md
@@ -6,7 +6,6 @@ draft: false
 image: img/blog/lake_reflection.jpg
 author: Patrick Deziel
 category: Programming, Mocks, Golang
-photo_credit: Dave Hoefler via Unsplash
 description: "A mock is a common pattern for unit testing interdependent services. In this post we will explore creating mocks in Go."
 profile: img/team/patrick-deziel.png
 ---
@@ -262,7 +261,7 @@ Mocks can help us bypass code that we don't want to run in our tests without fun
 
 ---
 
-<!-- Photo by [Dave Hoefler](https://unsplash.com/@davehoefler?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/pond-reflection?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) -->
+Photo by [Dave Hoefler](https://unsplash.com/@davehoefler?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/pond-reflection?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
 
 #### Code References
 

--- a/content/en/blog/2022-01-13-data-curation-baleen.md
+++ b/content/en/blog/2022-01-13-data-curation-baleen.md
@@ -6,7 +6,6 @@ draft: false
 image: img/blog/whale.jpg
 author: Nabiha Naqvie
 category: "Data Engineering"
-photo_credit: Art of Backpacking via Flickr
 description: "Recent developments in Artificial Intelligence (AI) and Natural Language Processing (NLP) indicate a growing need for better mechanisms for collecting curated datasets, and introduces a new open source tool for this purpose."
 profile: img/team/nabiha-naqvie.png
 ---
@@ -43,9 +42,7 @@ So how can you create your own curate data to ensure your machine learning model
 
 ---
 
-<!-- Photo by [Art of Backpacking](https://flic.kr/p/8GAVjS) on [Flickr Commons](https://flic.kr/p/8GAVjS)
-
---- -->
+Photo by [Art of Backpacking](https://flic.kr/p/8GAVjS) on [Flickr Commons](https://flic.kr/p/8GAVjS)
 
 [^1]: https://builtin.com/artificial-intelligence/ai-companies-roundup
 [^2]: https://www.urbint.com/about

--- a/content/en/blog/2022-05-04-achieving-total-ordering-with-crdts.md
+++ b/content/en/blog/2022-05-04-achieving-total-ordering-with-crdts.md
@@ -6,7 +6,6 @@ draft: false
 author: Patrick Deziel
 image: img/blog/hourglass.jpg
 category: "Distributed Systems"
-photo_credit: Aron Visuals via Unsplash
 description: "Conflict-free replicated data types are starting to take off in popularity, especially in terms of collaborative applications. In this post we will explore how these data structures can be used to achieve a total ordering of events across many peers."
 profile: img/team/patrick-deziel.png
 ---
@@ -200,9 +199,7 @@ Feel free to check out our open source demo [client](https://github.com/rotation
 
 ---
 
-<!-- Photo by [Aron Visuals](https://unsplash.com/@aronvisuals?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/time?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
-
---- -->
+Photo by [Aron Visuals](https://unsplash.com/@aronvisuals?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/time?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
 
 #### Further Reading
 

--- a/content/en/blog/2022-06-06-six-things-you-didnt-know-about-crypto.md
+++ b/content/en/blog/2022-06-06-six-things-you-didnt-know-about-crypto.md
@@ -6,7 +6,6 @@ draft: false
 author: Edwin S. & Rebecca B.
 image: img/blog/viking_runes.jpg
 category: Crypto
-photo_credit: Victor Montol via Flickr Commons
 description: "This post describes some of the most important facts about cryptocurrency that people don't often understand -- including crypto people!"
 profile: img/butterfly.png
 ---
@@ -79,9 +78,7 @@ While cryptocurrency has been around for more than a decade, vendors and enginee
 
 ---
 
-<!-- Photo by [Victor Montol](https://www.flickr.com/photos/vicmontol/) on [Flickr Commons](https://flic.kr/p/PRU1W)
-
---- -->
+Photo by [Victor Montol](https://www.flickr.com/photos/vicmontol/) on [Flickr Commons](https://flic.kr/p/PRU1W)
 
 #### References
 

--- a/content/en/blog/2022-06-20-five-technologies-quietly-transforming-the-web.md
+++ b/content/en/blog/2022-06-20-five-technologies-quietly-transforming-the-web.md
@@ -6,7 +6,6 @@ draft: false
 author: Edwin Schmierer
 image: img/blog/dawn.jpg
 category: WASM, AI/ML, gRPC, Microservices
-photo_credit: Rajiv Bajaj via Unplash
 description: "This post describes five technologies - new and old - that are transforming the web and becoming the foundation for next-generation applications."
 profile: img/team/edwin-schmierer.png
 ---
@@ -82,6 +81,4 @@ At Rotational, we think deeply about these issues and how to support developers 
 
 ---
 
-<!-- Photo by [Rajiv Bajaj](https://unsplash.com/@rajiv63) on [Unsplash](https://unsplash.com/photos/FsCh8MFy8Xs)
-
---- -->
+Photo by [Rajiv Bajaj](https://unsplash.com/@rajiv63) on [Unsplash](https://unsplash.com/photos/FsCh8MFy8Xs)

--- a/content/en/blog/2022-07-08-transparently-mocking-grpc-services.md
+++ b/content/en/blog/2022-07-08-transparently-mocking-grpc-services.md
@@ -332,10 +332,9 @@ Mocking gRPC services for the purposes of testing isn't always straightforward. 
 Check out the full tutorial code [here](https://github.com/rotationalio/agenda).
 
 ---
+Photo by [JJ Ying](https://unsplash.com/@jjying?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/technology?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
 
-<!-- Photo by [JJ Ying](https://unsplash.com/@jjying?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/technology?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
-
---- -->
+---
 
 #### References
 

--- a/content/en/blog/2022-08-08-effective-programmers-read-code.md
+++ b/content/en/blog/2022-08-08-effective-programmers-read-code.md
@@ -6,7 +6,6 @@ draft: false
 author: Benjamin Bengfort
 image: img/blog/blazes.jpg
 category: Programming
-photo_credit: Nicholas_T via Flickr Commons
 description: "While we often think ourselves as authors of code we probably spend more time reading code than writing it. Changing our mindset to think of ourselves as avid code readers will make us more effective programmers."
 profile: img/team/benjamin-bengfort.png
 ---
@@ -57,9 +56,7 @@ Documentation is essential and should give us a high level overview of what the 
 
 ---
 
-<!-- Photo by [Nicholas_T](https://www.flickr.com/photos/nicholas_t/) via [Flickr Commons](https://flic.kr/p/NFnpAu)
-
---- -->
+Photo by [Nicholas_T](https://www.flickr.com/photos/nicholas_t/) via [Flickr Commons](https://flic.kr/p/NFnpAu)
 
 [^1]: My inspiration for the term "glass castle" comes from the ["mind palace"](https://www.smithsonianmag.com/arts-culture/secrets-sherlocks-mind-palace-180949567/) portrayed by Benedict Cumberbach as Sherlock Holmes in BBC's _Sherlock_ (2010). Sherlock uses the mind palace as a memory technique where memories are linked to objects arranged in specific places in the palace. I thought "palace" was a little too grandiose for what I did so I changed it to castle and modified it with "glass" to imply the fragility of the mental abstraction while programming. I suppose "mind glass castle" would be the full term but that was a little unwieldy.
 [^2]: My experience of the glass castle is as a graph or molecular structure which I can "see" in my mind. In fact, sight is the best way to describe my interaction with the castle, sort of like how "reading" (instead of "hearing") is the best way to describe how I consume an audiobook. It's a bit hard to describe what I see, just as it would be hard to describe a dream, and people's sensory experiences are unique. I think the important note here is that as you program, you should be mentally interacting with this model in a way that feels right to you, e.g. is it "movement", "tartness", or "touch" for you?

--- a/content/en/blog/2022-08-15-english-major-interns-in-tech.md
+++ b/content/en/blog/2022-08-15-english-major-interns-in-tech.md
@@ -6,7 +6,6 @@ draft: false
 author: Natasha White
 image: img/blog/paths.jpg
 category: Technology
-photo_credit: Elzbieta Pacuszka via Flickr Commons
 description: "Over the course of the past few months, I’ve had the pleasure of interning at Rotational as a technical writer. I’m excited to share a little bit about my experience and provide some insight from the perspective of someone who is entering the world of distributed systems for the first time."
 profile: img/team/natasha-white.png
 ---
@@ -47,6 +46,4 @@ I feel so grateful for the learning and growth opportunities I’ve been afforde
 
 ---
 
-<!-- Photo by [elzbietapacuszka](https://www.flickr.com/people/192219560@N03/) via [Flickr Commons](https://www.flickr.com/photos/192219560@N03/)
-
---- -->
+Photo by [elzbietapacuszka](https://www.flickr.com/people/192219560@N03/) via [Flickr Commons](https://www.flickr.com/photos/192219560@N03/)

--- a/content/en/blog/2022-09-10-eventing-platforms.md
+++ b/content/en/blog/2022-09-10-eventing-platforms.md
@@ -6,7 +6,6 @@ draft: false
 author: Rebecca Bilbro
 image: img/blog/herd.jpg
 category: Microservices, Eventing
-photo_credit: Rajarshi Mitra via Flickr Commons
 description: "In this post we'll explore some of the types of eventing platforms and discuss why it's not about deciding which is objectively the 'best', but about knowing how to select the best tool for a given context."
 profile: img/team/rebecca-bilbro.png
 ---
@@ -79,6 +78,4 @@ When you are in the architecture and design phase of a new application, rather t
 
 ---
 
-<!-- Photo by [Rajarshi Mitra](https://www.flickr.com/photos/tataimitra/) via [Flickr Commons](https://flic.kr/p/244actT)
-
---- -->
+Photo by [Rajarshi Mitra](https://www.flickr.com/photos/tataimitra/) via [Flickr Commons](https://flic.kr/p/244actT)

--- a/content/en/blog/2022-09-23-why-webassembly-is-the-future-of-computing.md
+++ b/content/en/blog/2022-09-23-why-webassembly-is-the-future-of-computing.md
@@ -5,7 +5,6 @@ date: "2022-09-27T08:51:27-04:00"
 draft: false
 author: Danielle Maxwell
 image: img/blog/rocket.jpeg
-photo_credit: Bill Jelen on Unsplash
 category: WASM
 description: "Learn about WebAssembly, how it is currently transforming web development, and why its future is bright."
 profile: img/team/danielle-maxwell.png
@@ -71,9 +70,9 @@ To some, WASM may be the future of computing. However, I think it is the moment.
 
 ---
 
-<!-- Photo by [Bill Jelen](https://unsplash.com/@billjelen?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/speed?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
+Photo by [Bill Jelen](https://unsplash.com/@billjelen?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/speed?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
 
---- -->
+---
 
 #### References
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -38,8 +38,6 @@
   translation: Written by
 - id: sharePost
   translation: Share this post
-- id: photoCredit
-  translation: Photo credit
 - id: enterEmailToSubscribe
   translation: Enter Your Email To Subscribe
 - id: newsLetterEngagment

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -52,8 +52,6 @@
           <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg"><span
             class="ml-3">{{ .Params.author }}</span>
         </div>
-        <div class="text-lg text-[#1D65A6] font-bold mb-3">{{ i18n "photoCredit" }}:</div>
-        <p>{{ .Params.photo_credit }}</p>
       </div>
       <div class="sm:ml-10 sm:mt-0 mt-12">
         <div class="text-lg text-[#1D65A6] font-bold mb-3">{{ i18n "sharePost" }}:</div>


### PR DESCRIPTION
Scope of changes:

Removed photo credits from "About This Post" section.
Removed photo_credits tag from blog posts and displayed photo credits above the "About This Post" section.
Removed photo credits from en.yaml

