### PR TITLE
Add twitter meta tags

### DIFF
--- a/layouts/partials/site-head.html
+++ b/layouts/partials/site-head.html
@@ -3,13 +3,17 @@
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="twitter:card" content="summary">
 {{ with .Params.Image }}
 <meta property="og:image" content="{{ . | absURL }}" />
+<meta name="twitter:image" content="{{ . | absURL }}" />
 {{ end }}
 {{ with .Params.Title }}
  <meta property="og:title" content="{{ . }}" />
+ <meta name="twitter:title" content="{{ . }}" />
 {{ end }}
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}" />
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}" />
 {{ with site.Params.author }}
 	<meta name="author" content="{{ . }}">
 {{ end }}


### PR DESCRIPTION
Fixes SC-11645

Description of changes:
Twitter specific meta tags were added to the site's header after noting the app no longer works with the Open Graph (og) meta tags. Once approved, an image, description, and link should appear when sharing links from rotational.io on Twitter.

Below is a screenshot from Twitter's validator site showing that it detected the twitter:card tag following the change.

![Screenshot 2022-11-30 at 2 39 00 PM (2)](https://user-images.githubusercontent.com/94616884/204893184-6173f87c-2845-434c-94f5-30094cd928fe.png)

Twitter's validator site didn't show a preview image, so the below screenshot provides a preview of the change. The preview image displays the link used to test the site's meta tags in development. Once this is approved, the correct link will appear.

![Screenshot 2022-11-30 at 2 38 51 PM (2)](https://user-images.githubusercontent.com/94616884/204893320-98b73835-5a56-4e42-a286-0940a543b1de.png)

