### PR TITLE
Make blockquotes readable

### DIFF
--- a/static/output.css
+++ b/static/output.css
@@ -655,7 +655,7 @@ video {
 }
 
 .prose :where(blockquote):not(:where([class~="not-prose"] *)) {
-  font-weight: 500;
+  font-weight: 600;
   font-style: italic;
   color: var(--tw-prose-quotes);
   border-left-width: 0.25rem;


### PR DESCRIPTION
This PR resolves part of sc-14580 making italicized blockquotes heavier so that they are readable. However, I was not able to find any way to influence the weight of normal italicized text. @masskoder can you assist?



<img width="967" alt="Screen Shot 2023-03-13 at 6 36 33 PM" src="https://user-images.githubusercontent.com/8760385/224848042-77f999d4-7628-4098-8275-5d35a466994b.png">
