### PR TITLE
Changes draft status for data sources to false to create index of files

### DIFF
--- a/content/en/data-playground/dc-metro.md
+++ b/content/en/data-playground/dc-metro.md
@@ -2,7 +2,7 @@
 title: "Dc Metro"
 slug: "dc-metro"
 subtitle: "Stock Market Data" 
-draft: true
+draft: false
 image: img/data-playground/finnhub.png
 summary: Connect to stock market data and start experimenting with financial models and apps.
 github_link: "github.com"

--- a/content/en/data-playground/finnhub.md
+++ b/content/en/data-playground/finnhub.md
@@ -2,7 +2,7 @@
 title: "Finnhub"
 slug: "finnhub"
 subtitle: "Stock Market Data" 
-draft: true
+draft: false
 image: img/data-playground/finnhub.png
 link: "github.com"
 description: FinnHub provides real-time stock market data. Note that the stock market is closed during certain times of days and days of the week.

--- a/content/en/data-playground/noaa.md
+++ b/content/en/data-playground/noaa.md
@@ -2,7 +2,7 @@
 title: "Noaa"
 slug: "noaa"
 subtitle: "Stock Market Data" 
-draft: true
+draft: false
 image: img/data-playground/finnhub.png
 link: "github.com"
 description: FinnHub provides real-time stock market data. Note that the stock market is closed during certain times of days and days of the week.

--- a/content/en/data-playground/opensky.md
+++ b/content/en/data-playground/opensky.md
@@ -2,7 +2,7 @@
 title: "Opensky"
 slug: "opensky"
 subtitle: "Stock Market Data" 
-draft: true
+draft: false
 image: img/data-playground/finnhub.png
 link: "github.com"
 description: FinnHub provides real-time stock market data. Note that the stock market is closed during certain times of days and days of the week.

--- a/content/en/data-playground/steam.md
+++ b/content/en/data-playground/steam.md
@@ -2,7 +2,7 @@
 title: "Steam"
 slug: "steam"
 subtitle: "Stock Market Data" 
-draft: true
+draft: false
 image: img/data-playground/finnhub.png
 link: "github.com"
 description: FinnHub provides real-time stock market data. Note that the stock market is closed during certain times of days and days of the week.

--- a/content/en/data-playground/us-geological.md
+++ b/content/en/data-playground/us-geological.md
@@ -2,7 +2,7 @@
 title: "US Geological"
 slug: "us-geological"
 subtitle: "Stock Market Data" 
-draft: true
+draft: false
 image: img/data-playground/finnhub.png
 link: "github.com"
 description: FinnHub provides real-time stock market data. Note that the stock market is closed during certain times of days and days of the week.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "run-p dev:*",
     "build:css": "NODE_ENV=production npx tailwindcss -i input.css -o static/output.css -m",
     "build:hugo": "hugo",
-    "build": "run-s build:*"
+    "build": "run-s build:*",
+    "index": "hugo-lunr -i \"content/data-playground/*.md\" -o index.json"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -14,6 +15,7 @@
     "tailwindcss": "^3.1.8"
   },
   "dependencies": {
-    "@tailwindcss/typography": "^0.5.7"
+    "@tailwindcss/typography": "^0.5.7",
+    "hugo-lunr": "^0.0.4"
   }
 }


### PR DESCRIPTION
Adds ability to create an index.json file with data that may be used for search and filtering on the site. This also changes the draft status of content in `content/data-playground` to test creating an index from the files once they're built.

Fixes SC-17828