### PR TITLE
Adds links to data playground cards and removes search

### DIFF
--- a/content/en/data-playground/_index.md
+++ b/content/en/data-playground/_index.md
@@ -5,6 +5,6 @@ headertext: "Data Playground"
 subheadertext: "Streaming data sources and examples for your apps, models, and services"
 noicon: true
 type: "data-playground"
-is_search_enabled: true
+is_search_enabled: false
 is_filter_enabled: true
 ---

--- a/layouts/_default/playground-card.html
+++ b/layouts/_default/playground-card.html
@@ -1,15 +1,18 @@
 <div class="my-6 border border-solid border-[#000000] rounded-[9px] bg-[#ECF6FF]">
-    <img src="{{ .Params.image | absURL }}" alt="" class="m-0 rounded-t-lg h-60 w-full" />
+    <a href="{{.Permalink}}">
+        <img src="{{ .Params.image | absURL }}" alt="" class="m-0 rounded-t-lg h-60 w-full" />
+    </a>
     <div class="py-4 bg-[#E66809] text-xl text-white text-center">
+        <a href="{{.Permalink}}" class="block">
         {{ .Params.subtitle}}
+        </a>
     </div>
     <div class="mt-6 ml-4 max-h-[136px]">
         <div><span class="font-bold">Producer:</span> {{ .Params.producer_name }}</div>
         <div><span class="font-bold">License:</span> {{ .Params.license }}</div>
         <p class="mt-4 w-11/12">{{ .Params.summary}}</p>
     </div>
-    <div class="pb-6 mt-8">
-        <button class="bg-[#192E5B] block mx-auto w-1/2 rounded-xl py-4 hover:bg-[#1D65A6]"><a href="{{.Permalink}}"
-                class="text-white no-underline block">Learn More</a></button>
+    <div class="pb-6 mt-12">
+            <a href="{{.Permalink}}" class="text-white text-center no-underline block bg-[#192E5B] mx-auto w-1/2 rounded-xl py-4 hover:bg-[#1D65A6]">Learn More</a>
     </div>
 </div>

--- a/static/output.css
+++ b/static/output.css
@@ -1319,6 +1319,10 @@ video {
   margin-right: 3.5rem;
 }
 
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
 .block {
   display: block;
 }
@@ -1415,37 +1419,24 @@ video {
   height: 100px;
 }
 
-.h-\[622px\] {
-  height: 622px;
-}
-
-.max-h-20 {
-  max-height: 5rem;
-}
-
-.max-h-\[542px\] {
-  max-height: 542px;
-}
-
 .max-h-\[136px\] {
   max-height: 136px;
 }
 
-.max-h-36 {
-  max-height: 9rem;
+.max-h-\[150px\] {
+  max-height: 150px;
+}
+
+.max-h-\[662px\] {
+  max-height: 662px;
+}
+
+.max-h-\[650px\] {
+  max-height: 650px;
 }
 
 .min-h-\[480px\] {
   min-height: 480px;
-}
-
-.min-h-fit {
-  min-height: -moz-fit-content;
-  min-height: fit-content;
-}
-
-.min-h-\[622px\] {
-  min-height: 622px;
 }
 
 .w-10 {


### PR DESCRIPTION
Brief Description:

- Temporarily disables the search functionality on the data playground page. 
- Adds links to the image and subtitle while also making the `Learn More` link easier to click. 
- Adds some padding above the `Learn More` button.

Fixes SC-19206, SC-SC-19208, and SC-19209

Acceptance Criteria:
https://www.awesomescreenshot.com/video/19327839?key=abc9c9a04df74049072250d455102ad7