### PR TITLE
Update link on website

### DIFF
--- a/content/en/ensign-enterprise/index.md
+++ b/content/en/ensign-enterprise/index.md
@@ -34,7 +34,7 @@ How does Ensign stack up to other, similar tools and products? Also, see [our te
 
 {{< widefigure src="/img/ensign/tco_comparison.png" alt="Total Cost of Ownership">}}
 
-{{< ensigncoa btnhref="https://calendly.com/edwin-r8l/discussion" btntext="Schedule" >}}
+{{< ensigncoa btnhref="https://calendar.app.google/mURnKSUa3h3grbE39" btntext="Schedule" >}}
 Got questions? Schedule a friendly chat.
 {{< /ensigncoa >}}
 


### PR DESCRIPTION
This PR updates the "Schedule" button on the "Ensign for Enterprise" page to link to Edwin's 15 minute Google Calendar Scheduler rather than his Calendly scheduler:

![Screenshot 2023-08-15 at 07 26 43](https://github.com/rotationalio/rotational.io/assets/745966/7139c5e1-f232-4a4e-a545-8504500421b7)

@eschmier I'm pretty sure this is the only place I have to change your link; but if you can think of other places that need the change, let me know! 

@rebeccabilbro I have updated your schedule button link in Beacon in this PR: https://github.com/rotationalio/ensign/pull/652