### PR TITLE
Sc 21286/tags

### DIFF
--- a/input.css
+++ b/input.css
@@ -375,7 +375,7 @@ em {
 }
 
 .blog-tag::before {
-  content: ', ';
+  content: '| ';
 }
 
 .blog-tag:first-child::before {

--- a/input.css
+++ b/input.css
@@ -375,7 +375,7 @@ em {
 }
 
 .blog-tag::before {
-  content: ',\00a0';
+  content: ', ';
 }
 
 .blog-tag:first-child::before {

--- a/input.css
+++ b/input.css
@@ -375,7 +375,7 @@ em {
 }
 
 .blog-tag::before {
-  content: '| ';
+  content: ',\00a0';
 }
 
 .blog-tag:first-child::before {

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -4,14 +4,14 @@
     <div class="bg-[#ECF6FF] rounded-b-xl ">
 
         <div class="px-6 pt-4">
-            <ul class="flex flex-wrap">
+            <ul class="flex whitespace-nowrap">
                 {{ range .Params.tags }}
                     <li class="blog-tag text-base font-bold text-[#1D65A6]">
                         <a href="/tags/{{ . | urlize }}">{{ . }}</a>
                     </li> 
                 {{ end }}
             </ul>
-            <h3 class="text-xl font-extrabold mt-3 "><a class="block h-24" href="{{ .Permalink }}">{{ .Title }}</a>
+            <h3 class="text-xl font-extrabold mt-3 pb-2 "><a class="block h-24" href="{{ .Permalink }}">{{ .Title }}</a>
             </h3>
             <div class='art-s'>
                 <p class="mt-3 text-base font-extralight">{{ .Summary | safeHTML | truncate 240 }}</p>

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -4,7 +4,7 @@
     <div class="bg-[#ECF6FF] rounded-b-xl ">
 
         <div class="px-6 pt-4">
-            <ul class="flex">
+            <ul class="flex flex-wrap">
                 {{ range .Params.tags }}
                     <li class="blog-tag text-base font-bold text-[#1D65A6]">
                         <a href="/tags/{{ . | urlize }}">{{ . }}</a>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -3,9 +3,9 @@
 {{ end }}
 
 {{ define "main" }}
-<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+<div class="relative max-w-7xl mx-auto px-4 sm:px-2">
     <div class="mt-9 sm:mt-11 lg:mt-14">
-        <ul class="b-card">
+        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
             <li class="mt-6 sm:mt-0 h-auto">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -24,7 +24,7 @@
           end }}</b>
         {{ with .Title }} {{ after (len (index (split . " ") 0)) . | safeHTML }} {{ end }}
       </h3>
-      <div class="flex flex-wrap justify-center items-center mt-4">
+      <div class="flex flex-wrap justify-center items-center my-4">
         <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
           <span class="ml-3 blog-date">{{ .Params.author }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
           <ul class="flex whitespace-nowrap">
@@ -33,8 +33,7 @@
             {{ end }}
           </ul>
       </div>
-      <div class="flex justify-center mb-6">
-      </div>
+
       <article class="max-w-[800px] mx-auto prose">
         {{ .Content | safeHTML }}
       </article>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -24,16 +24,16 @@
           end }}</b>
         {{ with .Title }} {{ after (len (index (split . " ") 0)) . | safeHTML }} {{ end }}
       </h3>
-      <div class="flex justify-center items-center mt-4">
+      <div class="flex flex-wrap justify-center items-center mt-4">
         <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
-          <span class="ml-3 blog-date">{{ .Params.author }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }}</span>
+          <span class="ml-3 blog-date">{{ .Params.author }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
+          <ul class="flex whitespace-nowrap">
+            {{ range .Params.tags }}
+            <li class="blog-tag"><a href="/tags/{{ . | urlize }}"> {{ . }}</a></li>
+            {{ end }}
+          </ul>
       </div>
       <div class="flex justify-center mb-6">
-        <ul class="flex">
-          {{ range .Params.tags }}
-          <li class="blog-tag"><a href="/tags/{{ . | urlize }}"> {{ . }}</a></li>
-          {{ end }}
-        </ul>
       </div>
       <article class="max-w-[800px] mx-auto prose">
         {{ .Content | safeHTML }}

--- a/layouts/partials/recent-rotations.html
+++ b/layouts/partials/recent-rotations.html
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div>
-        <div class="sm:grid grid-cols-3 gap-8 sm:mt-16">
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 sm:mt-16">
             {{ range first 3 (where site.RegularPages "Section" "==" "blog")}}
             <div class="mt-6 ">
                 {{ .Render "article"}}

--- a/layouts/tags/term.html
+++ b/layouts/tags/term.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
     <div class="mt-9 sm:mt-11 lg:mt-14">
-        <ul class="b-card">
+        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
             <li class="mt-6 sm:mt-0 h-auto">

--- a/static/output.css
+++ b/static/output.css
@@ -1325,6 +1325,18 @@ video {
   margin-right: 3.5rem;
 }
 
+.ml-12 {
+  margin-left: 3rem;
+}
+
+.ml-14 {
+  margin-left: 3.5rem;
+}
+
+.ml-16 {
+  margin-left: 4rem;
+}
+
 .block {
   display: block;
 }
@@ -1601,6 +1613,10 @@ video {
   align-items: center;
 }
 
+.justify-start {
+  justify-content: flex-start;
+}
+
 .justify-center {
   justify-content: center;
 }
@@ -1613,12 +1629,12 @@ video {
   gap: 2rem;
 }
 
-.gap-10 {
-  gap: 2.5rem;
-}
-
 .gap-6 {
   gap: 1.5rem;
+}
+
+.gap-10 {
+  gap: 2.5rem;
 }
 
 .gap-4 {
@@ -1660,6 +1676,18 @@ video {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.whitespace-pre {
+  white-space: pre;
+}
+
+.whitespace-pre-line {
+  white-space: pre-line;
 }
 
 .rounded-full {
@@ -2098,6 +2126,10 @@ video {
   padding-top: 1rem;
 }
 
+.pb-2 {
+  padding-bottom: 0.5rem;
+}
+
 .pb-6 {
   padding-bottom: 1.5rem;
 }
@@ -2132,10 +2164,6 @@ video {
 
 .pl-10 {
   padding-left: 2.5rem;
-}
-
-.pb-2 {
-  padding-bottom: 0.5rem;
 }
 
 .pb-3 {
@@ -2825,7 +2853,7 @@ em {
 }
 
 .blog-tag::before {
-  content: ',\00a0';
+  content: ', ';
 }
 
 .blog-tag:first-child::before {
@@ -2877,6 +2905,16 @@ em {
 @media (max-width: 650px) {
   .max-\[650px\]\:text-center {
     text-align: center;
+  }
+}
+
+@media (min-width: 300px) {
+  .min-\[300px\]\:grid {
+    display: grid;
+  }
+
+  .min-\[300px\]\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
@@ -2932,6 +2970,10 @@ em {
     margin-left: 5rem;
   }
 
+  .sm\:ml-0 {
+    margin-left: 0px;
+  }
+
   .sm\:inline {
     display: inline;
   }
@@ -2968,6 +3010,10 @@ em {
     grid-template-columns: repeat(7, minmax(0, 1fr));
   }
 
+  .sm\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .sm\:flex-row {
     flex-direction: row;
   }
@@ -2992,6 +3038,11 @@ em {
 
   .sm\:p-0 {
     padding: 0px;
+  }
+
+  .sm\:px-2 {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
   }
 
   .sm\:px-6 {
@@ -3057,6 +3108,24 @@ em {
   }
 }
 
+@media (min-width: 650px) {
+  .min-\[650px\]\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 700px) {
+  .min-\[700px\]\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 750px) {
+  .min-\[750px\]\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 768px) {
   .md\:my-4 {
     margin-top: 1rem;
@@ -3103,6 +3172,10 @@ em {
     margin-top: 2.5rem;
   }
 
+  .md\:ml-0 {
+    margin-left: 0px;
+  }
+
   .md\:flex {
     display: flex;
   }
@@ -3131,12 +3204,12 @@ em {
     max-width: 24rem;
   }
 
-  .md\:grid-cols-4 {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
   .md\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .md\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .md\:grid-cols-3 {
@@ -3153,6 +3226,10 @@ em {
 
   .md\:justify-between {
     justify-content: space-between;
+  }
+
+  .md\:gap-8 {
+    gap: 2rem;
   }
 
   .md\:gap-x-32 {
@@ -3218,6 +3295,12 @@ em {
 
   .md\:leading-snug {
     line-height: 1.375;
+  }
+}
+
+@media (min-width: 800px) {
+  .min-\[800px\]\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
@@ -3314,6 +3397,10 @@ em {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
+  .lg\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .lg\:px-12 {
     padding-left: 3rem;
     padding-right: 3rem;
@@ -3366,6 +3453,10 @@ em {
 
   .xl\:w-\[96\%\] {
     width: 96%;
+  }
+
+  .xl\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .xl\:leading-tight {

--- a/static/output.css
+++ b/static/output.css
@@ -2825,7 +2825,7 @@ em {
 }
 
 .blog-tag::before {
-  content: ', ';
+  content: '| ';
 }
 
 .blog-tag:first-child::before {

--- a/static/output.css
+++ b/static/output.css
@@ -2825,7 +2825,7 @@ em {
 }
 
 .blog-tag::before {
-  content: '| ';
+  content: ',\00a0';
 }
 
 .blog-tag:first-child::before {


### PR DESCRIPTION
Scope of Changes:

Improves responsiveness of pages where blog posts are listed to ensure blog tags appear on one line and don't overflow container. Additional padding has also been added between the blog post titles and descriptions to prevent titles from covering descriptions on smaller screens.

Fixes SC-21286

Acceptance Criteria:

Sizzy Screenshots of a blog post with multiple blog tags:
![Sizzy-Nexus 7 localhost 20Sep 11 06](https://github.com/rotationalio/rotational.io/assets/94616884/b399c1d0-6663-4101-896d-4d7218375c24)

![Sizzy-Laptop S localhost 20Sep 11 06](https://github.com/rotationalio/rotational.io/assets/94616884/5718ce33-40fd-4674-b5dd-2f7d6c15571a)

![Sizzy-Galaxy S20 Ultra localhost 20Sep 11 06](https://github.com/rotationalio/rotational.io/assets/94616884/4ddae4b5-60b5-4202-a6f3-6575cfcce640)
