### PR TITLE
Adds link to blog post authors name

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -5,7 +5,7 @@ date: "{{ .Date }}"
 draft: false
 image: img/blog/
 photo_credit: "Add Photo Credits Here"
-author: Your Name
+authors: ['Your Name', 'Co-Authors Name']
 profile: img/team/your-name.png
 tags: ['Add Tag 1 Here', 'Add Tag 2 Here']
 description: "Add Description Here"

--- a/config.toml
+++ b/config.toml
@@ -163,5 +163,3 @@ mediaType = "text/plain"
 [taxonomies]
   tag = 'tags'
   author = 'authors'
-
-disableKinds = ["taxonomyTerm"]

--- a/config.toml
+++ b/config.toml
@@ -159,3 +159,9 @@ blog = ["HTML", "RSS"]
 baseName = "humans"
 isPlainText = true
 mediaType = "text/plain"
+
+[taxonomies]
+  tag = 'tags'
+  author = 'authors'
+
+disableKinds = ["taxonomyTerm"]

--- a/content/en/authors/aatmaj-janardanan/_index.md
+++ b/content/en/authors/aatmaj-janardanan/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Aatmaj Janardanan"
+slug: "aatmaj-janardanan"
+profile: img/team/aatmaj-janardanan.png
+designation : Data Science Intern
+field: Machine Learning Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/aatmaj-janardanan-104216140/'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/Aatmaj1'
+    icon: 'fa-github'
+---
+Aatmaj Janardanan is a passionate data scientist on a mission to extract meaningful insights from complex datasets.

--- a/content/en/authors/amanda-stanley/_index.md
+++ b/content/en/authors/amanda-stanley/_index.md
@@ -1,0 +1,13 @@
+---
+name: "Amanda Stanley"
+slug: "amanda-stanley"
+profile: img/team/amanda-stanley.png
+designation: Head of Growth
+field: Product Marketing Advisor
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/stanleyamandak/'
+    icon: 'fa-linkedin-in'
+---
+
+Amanda is Head of Growth at Rotational Labs. A seasoned zero-to-one product leader, Amanda has led product, strategy, and innovation projects for private- and public-sector organizations on five continents, including a former U.S. President, the CEO of one of Germany’s largest conglomerates, and technology start-ups in emerging markets. In her role at Rotational, she focuses on go-to-market, product positioning and messaging, and content strategy.

--- a/content/en/authors/beci-lambrecht/_index.md
+++ b/content/en/authors/beci-lambrecht/_index.md
@@ -1,0 +1,8 @@
+---
+name: "Beci Lambrecht"
+slug: "beci-lambrecht"
+profile: img/team/beci-lambrecht.png
+designation : Project Management Support
+field: Certified PMP & Agile Specialist
+---
+Beci works to support project management tasks at Rotational Labs through organization, workflow analysis, and communication. With over 15 years of sales and management experience in the agriculture industry, she enjoys incorporating her skill set in a new sector with Rotational's growing team. When not at work, she can probably be found on a horse, somewhere on her family's ranch.

--- a/content/en/authors/benjamin-bengfort/_index.md
+++ b/content/en/authors/benjamin-bengfort/_index.md
@@ -1,0 +1,18 @@
+---
+name: "Benjamin Bengfort, Ph.D. "
+slug: "benjamin-bengfort"
+profile: img/team/benjamin-bengfort.png
+designation : Founder/CEO
+field: The Vision
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/bbengfort/'
+    icon: 'fa-linkedin-in'
+  - name : "twitter" # themify icon pack : https://themify.me/themify-icons
+    link : "https://twitter.com/bbengfort"
+    icon: 'fa-twitter'
+  - name : "github"
+    link: 'https://github.com/bbengfort'
+    icon: 'fa-github'
+---
+Dr. Benjamin Bengfort is co-founder and CEO of Rotational Labs. Benjamin is an experienced systems engineer, programmer and data scientist. Driven by a desire to build large systems with many users that have a global impact, he takes pride in solutions where many small interactions combine to create complex dynamics. As the CEO of Rotational Labs, his goal is to apply advanced distributed computing, networking, open source software, education, and machine learning to solutions that allow us to collaborate more effectively around the world to solve big problems.

--- a/content/en/authors/cletus-razakou/_index.md
+++ b/content/en/authors/cletus-razakou/_index.md
@@ -1,0 +1,18 @@
+---
+name: "Cletus Razakou"
+slug: "cletus-razakou"
+profile: img/team/cletus-razakou.png
+designation : Senior Front-end Engineer
+field: React.JS Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/cletusrazakou/'
+    icon: 'fa-linkedin-in'
+  - name : "twitter" # themify icon pack : https://themify.me/themify-icons
+    link : "https://twitter.com/masskoder"
+    icon: 'fa-twitter'
+  - name : "github"
+    link: 'https://github.com/masskoder'
+    icon: 'fa-github'
+---
+Cletus Razakou is a Senior Front-end engineer at Rotational Labs. He has more than a decade of experience in full-stack development, most often using Typescript, ReactJS, Angular, Dart, C# and NodeJS. He also has experience in leading engineering teams building scalable products. Aside from work, he loves spending time with his daughter, reading, traveling to new places, and discovering new foods.

--- a/content/en/authors/daniel-sollis/_index.md
+++ b/content/en/authors/daniel-sollis/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Daniel Sollis"
+slug: "daniel-sollis"
+profile: img/team/daniel-sollis.png
+designation : Jr Distributed Systems Engineer
+field: Architecture Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/daniel-sollis-67481114a'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/DanielSollis'
+    icon: 'fa-github'
+---
+Daniel Sollis is a Junior Distributed Systems Engineer working at Rotational Labs. Daniel is a skilled programmer with experience working in Golang, Python and C++. Daniel spends most of his free time playing guitar, reading, hiking and generally staying fit.

--- a/content/en/authors/danielle-maxwell/_index.md
+++ b/content/en/authors/danielle-maxwell/_index.md
@@ -1,0 +1,18 @@
+---
+name: "Danielle Maxwell"
+slug: "danielle-maxwell"
+profile: img/team/danielle-maxwell.png
+designation : Jr Distributed Systems Engineer
+field: WebAssembly Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/daniellemaxwell'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/daniellemaxwell'
+    icon: 'fa-github'
+  - name : "twitter" # themify icon pack : https://themify.me/themify-icons
+    link : "https://twitter.com/thedanimaxwell"
+    icon: 'fa-twitter'
+---
+Danielle Maxwell is a Junior Distributed Systems Engineer at Rotational Labs. Danielle’s experience with full-stack development helps form a bridge between the front-end and back-end. Prior to becoming a software developer, Danielle was an ESL teacher and entrepreneur.  When she can, Danielle enjoys discovering new foods while traveling and practicing her somewhat intelligible Spanish.

--- a/content/en/authors/edwin-schmierer/_index.md
+++ b/content/en/authors/edwin-schmierer/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Edwin Schmierer"
+slug: "edwin-schmierer"
+profile: img/team/edwin-schmierer.png
+designation : Founder/COO
+field: The Business
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in//edwinschmierer/'
+    icon: 'fa-linkedin-in'
+  - name : "twitter" # themify icon pack : https://themify.me/themify-icons
+    link : "https://twitter.com/ESchmierer"
+    icon: 'fa-twitter'
+---
+Edwin Schmierer is co-founder and COO of Rotational Labs. Edwin is an accomplished business executive and leader. He has over 20 years of experience leading high-impact organizations and teams in both the private sector and academia. In his role as COO, he focuses on strategy, marketing, finance, operations, and product development.

--- a/content/en/authors/elysee-bleu/_index.md
+++ b/content/en/authors/elysee-bleu/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Elysee Bleu"
+slug: "elysee-bleu"
+profile: img/team/elysee-bleu.png
+designation : Front-end Engineer
+field: React.JS Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/elys%C3%A9e-bleu-00078a172/'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/elysee15'
+    icon: 'fa-github'
+---
+Elysee Bleu is a Junior front-end developer with over 2 years of experience. He also has some knowledge and experience in back-end development. As a front-end developer, his job is to create user interfaces and maintain the client side web applications. In his spare time, he loves reading, watching movies and spending time with his family and friends.

--- a/content/en/authors/jennifer-lieberman/_index.md
+++ b/content/en/authors/jennifer-lieberman/_index.md
@@ -1,0 +1,12 @@
+---
+name: "Jennifer Lieberman"
+slug: "jennifer-lieberman"
+designation : Contributing Author
+field: Interdisciplinary Scholar
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/jenni-lieberman-ph-d-6bb5588/'
+    icon: 'fa-linkedin-in'
+---
+
+Jennifer L. Lieberman is an associate professor of English at the University of North Florida (UNF) and the Director of the Office of Interdisciplinary Programs, overseeing Africana Studies, Interdisciplinary Studies, and International Studies. She is the author of Power Lines: Electricity in American Life and Letters, 1882-1952, which is available from [Amazon](https://www.amazon.com/Power-Lines-Electricity-1882-1952-Technology/dp/0262036371/ref=sr_1_1?s=books&ie=UTF8&qid=1502393406&sr=1-1&keywords=power+lines).

--- a/content/en/authors/karen-belita/_index.md
+++ b/content/en/authors/karen-belita/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Karen Belita"
+slug: "karen-belita"
+profile: img/team/karen-belita.png
+designation : Software Engineer
+field: DevOps Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/karenbelita/'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/kbelita'
+    icon: 'fa-github'
+---
+Karen Belita is an engineer who brings experience from the data analysis and machine learning domains. A longtime Adjunct Faculty member at Georgetown University, Karen coaches students as they progress through their capstone projects in the Data Science Certificate Program. She enjoys combining her problem solving skills, love of good documentation, and advanced data analytics and visualization skills to optimize cluster management and container orchestration.

--- a/content/en/authors/nabiha-naqvie/_index.md
+++ b/content/en/authors/nabiha-naqvie/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Nabiha Naqvie"
+slug: "nabiha-naqvie"
+profile: img/team/nabiha-naqvie.png
+designation : Open Source Contributor
+field: Natural Language Processing Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/nabiha-naqvie-22765612a/'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/nabihanaqvie'
+    icon: 'fa-github'
+---
+Nabiha Naqvie is a data scientist with a background in molecular biology and an interest in Data Engineering, Applied Natural Language Processing and Distributed Systems.

--- a/content/en/authors/natasha-white/_index.md
+++ b/content/en/authors/natasha-white/_index.md
@@ -1,0 +1,12 @@
+---
+name: "Natasha White"
+slug: "natasha-white"
+profile: img/team/natasha-white.png
+designation : Technical Writing Intern
+field: Documentation Specialist
+social :
+  - name : "github"
+    link: 'https://github.com/nwhite222'
+    icon: 'fa-github'
+---
+Natasha White is a technical writer and college student with rather intimidating volleyball skills.

--- a/content/en/authors/patrick-deziel/_index.md
+++ b/content/en/authors/patrick-deziel/_index.md
@@ -1,0 +1,18 @@
+---
+name: "Patrick Deziel"
+slug: "patrick-deziel"
+profile: img/team/patrick-deziel.png
+designation : Distributed Systems Engineer
+field: Machine Learning Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/patrick-deziel-9b19b2210'
+    icon: 'fa-linkedin-in'
+  - name : "twitter" # themify icon pack : https://themify.me/themify-icons
+    link : "https://twitter.com/PatrickDeziel"
+    icon: 'fa-twitter'
+  - name : "github"
+    link: 'https://github.com/pdeziel'
+    icon: 'fa-github'
+---
+Patrick Deziel is a distributed systems engineer and machine learning specialist. Patrick has extensive experience building and maintaining mission-critical systems in the private sector, as well as integrating modern ML solutions into existing applications. At Rotational, he designs and builds intelligent distributed systems to enable global use cases. In his free time, Patrick enjoys rock climbing and consuming science fiction.

--- a/content/en/authors/pete-keleher/_index.md
+++ b/content/en/authors/pete-keleher/_index.md
@@ -1,0 +1,12 @@
+---
+name: "Pete Keleher"
+slug: "pete-keleher"
+profile: img/team/pete-keleher.png
+designation : Technical Advisor
+field: Distributed Systems Researcher
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/pete-keleher-a03639b'
+    icon: 'fa-linkedin-in'
+---
+Dr. Peter Keleher is a professor in the Computer Science department at University of Maryland. His research centers on Distributed Systems and Cloud Storage.

--- a/content/en/authors/prema-roman/_index.md
+++ b/content/en/authors/prema-roman/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Prema Roman"
+slug: "prema-roman"
+profile: img/team/prema-roman.png
+designation : Distributed Systems Engineer
+field: MLOps Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/premaroman'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/pdamodaran'
+    icon: 'fa-github'
+---
+Prema Roman is a distributed systems engineer at Rotational Labs.  She is an experienced software, data, and machine learning engineer with a proven track record of building high quality software applications and data products.  Her passion for continuous learning has taken her a long way from her start as a data analyst, as she takes on new challenges at Rotational Labs building globally distributed systems and machine learning data products.

--- a/content/en/authors/rebecca-bilbro/_index.md
+++ b/content/en/authors/rebecca-bilbro/_index.md
@@ -1,0 +1,18 @@
+---
+name: "Rebecca Bilbro, Ph.D"
+slug: "rebecca-bilbro"
+profile: img/team/rebecca-bilbro.png
+designation : Founder/CTO
+field: The Vision
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/rebeccabilbro/'
+    icon: 'fa-linkedin-in'
+  - name : "twitter" # themify icon pack : https://themify.me/themify-icons
+    link : "https://twitter.com/rebeccabilbro"
+    icon: 'fa-twitter'
+  - name : "github"
+    link: 'https://github.com/rebeccabilbro'
+    icon: 'fa-github'
+---
+Dr. Rebecca Bilbro a data scientist, Python and Go programmer, teacher, speaker, and author who has worked in numerous startups from public sector to media & entertainment to enterprise security. As co-founder and CTO of Rotational Labs, she specializes in machine learning optimization and API development in distributed data systems. Rebecca is motivated by a desire to make distributed systems more accessible to everyday developers and data scientists. She is also an active contributor to open source software and is the creator and maintainer of the popular Yellowbrick library (scikit-yb.org), an open source Python package that hooks into the popular scikit-Learn API to support visual feature analysis, model selection, and hyperparameter tuning for data scientists and machine learning practitioners.

--- a/content/en/authors/tianshu-li/_index.md
+++ b/content/en/authors/tianshu-li/_index.md
@@ -1,0 +1,15 @@
+---
+name: "Tianshu Li"
+slug: "tianshu-li"
+profile: img/team/tianshu-li.png
+designation : Open Source Contributor
+field: Machine Learning Specialist
+social :
+  - name : "linkedin"
+    link: 'https://www.linkedin.com/in/tianshu-li-5b5563b0/'
+    icon: 'fa-linkedin-in'
+  - name : "github"
+    link: 'https://github.com/tl6kk'
+    icon: 'fa-github'
+---
+Tianshu Li is a data scientist and NLP specialist with a PhD in Systems Engineering and an enduring curiosity for learning, open source, and new culinary adventures.

--- a/content/en/blog/2021-01-21-hello-world.md
+++ b/content/en/blog/2021-01-21-hello-world.md
@@ -4,7 +4,7 @@ slug: "hello-world"
 date: "2021-01-21T16:20:18-04:00"
 draft: false
 image: img/blog/2021-01-21-hello-world/gulfatnight.jpg
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 tags: ['Distributed Systems']
 description: "Hello World! We're Rotational Labs."
 profile: img/team/benjamin-bengfort.png

--- a/content/en/blog/2021-02-12-grpc-openapi-docs.md
+++ b/content/en/blog/2021-02-12-grpc-openapi-docs.md
@@ -3,7 +3,7 @@ title: "Documenting a gRPC API with OpenAPI"
 slug: "documenting-grpc-with-openapi"
 date: 2021-02-12T17:45:35Z
 image: img/blog/2021-02-12-grpc-openapi-docs/gateway.jpg
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 tags: ['gRPC', 'Programming', 'Golang']
 description: "Using grpc-gateway and Swagger"
 profile: img/team/benjamin-bengfort.png

--- a/content/en/blog/2021-03-19-a-parrot-trainer-eats-crow.md
+++ b/content/en/blog/2021-03-19-a-parrot-trainer-eats-crow.md
@@ -4,7 +4,7 @@ slug: "a-parrot-trainer-eats-crow"
 date: "2021-03-19T08:42:21-04:00"
 draft: false
 image: img/blog/2021-03-19-a-parrot-trainer-eats-crow/parrots.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 tags: ['AI', 'ML']
 description: "Models trained on massive datasets using millions of parameters can both have low bias and also be very biased - what can we in the ML community do about this?"
 profile: img/team/rebecca-bilbro.png

--- a/content/en/blog/2021-03-24-project-planning-with-block-based-dependencies.md
+++ b/content/en/blog/2021-03-24-project-planning-with-block-based-dependencies.md
@@ -5,7 +5,7 @@ date: "2021-03-24T07:49:48-04:00"
 draft: false
 image_webp: img/blog/2021-03-24-project-planning-with-block-based-dependencies/2021-03-24-blocks-dependencies.png
 image: img/blog/2021-03-24-project-planning-with-block-based-dependencies/2021-03-24-blocks-dependencies.png
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 tags: ['Project Management']
 description: "A temporal block based dependency method for planning complex projects."
 profile: img/team/benjamin-bengfort.png

--- a/content/en/blog/2021-04-06-a-distributed-systems-maze.md
+++ b/content/en/blog/2021-04-06-a-distributed-systems-maze.md
@@ -4,7 +4,7 @@ slug: "a-distributed-systems-maze"
 date: "2021-04-06T13:49:57-04:00"
 draft: false
 image: img/blog/2021-04-06-a-distributed-systems-maze/maze.jpg
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 tags: ['Distributed Systems']
 description: "Distributed systems jargon can feel like a maze that your constantly lost in. In this post we try to see our way clear with a maze metaphor to understand why coordination is necessary, and difficult."
 profile: img/team/benjamin-bengfort.png

--- a/content/en/blog/2021-04-27-cant-read-wont-buy.md
+++ b/content/en/blog/2021-04-27-cant-read-wont-buy.md
@@ -4,7 +4,7 @@ slug: "cant-read-wont-buy"
 date: "2021-04-27T11:24:40-04:00"
 draft: false
 image: img/blog/2021-04-27-cant-read-wont-buy/streetblur.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 tags: ['i18n']
 description: "In this post we'll explore some of the drawbacks of using only English as a sales medium, check out some creative solutions, identify some areas of caution, and consider what this all means to the future of global app development."
 profile: img/team/rebecca-bilbro.png

--- a/content/en/blog/2021-05-02-contexts-in-go-microservice-chains.md
+++ b/content/en/blog/2021-05-02-contexts-in-go-microservice-chains.md
@@ -4,7 +4,7 @@ slug: "contexts-in-go-microservice-chains"
 date: "2021-05-02T14:24:33-04:00"
 draft: false
 image: img/blog/2021-05-02-contexts-in-go-microservice-chains/arboreal.jpg
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 tags: ['Microservices', 'Golang', 'Programming']
 description: "Contexts are a critical part of services implemented in Golang, but although we see them often in server interfaces, they can be a bit mysterious to developers implementing request handlers. In this post, we look at a specific example where contexts shine: handlers that have to call multiple internal microservices to serve their response."
 profile: img/team/benjamin-bengfort.png

--- a/content/en/blog/2021-05-19-what-are-protocol-buffers.md
+++ b/content/en/blog/2021-05-19-what-are-protocol-buffers.md
@@ -4,7 +4,7 @@ slug: "what-are-protocol-buffers"
 date: "2021-05-19T11:05:32-04:00"
 draft: false
 image: img/blog/2021-05-19-what-are-protocol-buffers/migration.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 tags: ['gRPC']
 description: "Protocol buffers are a method for serializing data to efficiently send between programs. In this post, we'll explore some use cases for protobufs and learn the syntax."
 profile: img/team/rebecca-bilbro.png

--- a/content/en/blog/2021-06-01-secrets-manager-with-go.md
+++ b/content/en/blog/2021-06-01-secrets-manager-with-go.md
@@ -4,7 +4,7 @@ slug: "secrets-manager-with-go"
 date: "2021-06-01T08:26:38-04:00"
 draft: false
 image: img/blog/2021-06-01-secrets-manager-with-go/doorknocker.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 tags: ['Security', 'Golang', 'Programming']
 description: "In this post, we'll dive into Google's Secret Manager service, walk through the setup steps, and explore some Go code to interact with the API."
 profile: img/team/rebecca-bilbro.png

--- a/content/en/blog/2021-06-10-ux-whats-missing.md
+++ b/content/en/blog/2021-06-10-ux-whats-missing.md
@@ -4,7 +4,7 @@ slug: "ux-whats-missing"
 date: 2021-06-10T17:20:00Z
 tags: ['UX', 'Technology']
 image: img/blog/2021-06-10-ux-whats-missing/window.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 profile: img/team/rebecca-bilbro.png
 ---
 

--- a/content/en/blog/2021-07-06-cloud-generations.md
+++ b/content/en/blog/2021-07-06-cloud-generations.md
@@ -4,7 +4,7 @@ slug: "cloud-generations"
 date: 2021-07-02T15:32:47-04:00
 draft: false
 image: img/blog/2021-07-06-cloud-generations/cloudgeneration.jpg
-author: Edwin Schmierer
+authors: [Edwin Schmierer]
 tags: ['Cloud', 'Technology']
 description: "How the public cloud has evolved and where it is headed"
 profile: img/team/edwin-schmierer.png

--- a/content/en/blog/2021-08-30-data-privacy-laws.md
+++ b/content/en/blog/2021-08-30-data-privacy-laws.md
@@ -4,7 +4,7 @@ slug: "data-privacy-laws"
 date: 2021-08-31T17:32:47-04:00
 draft: false
 image: img/blog/islands.jpg
-author: Edwin Schmierer
+authors: [Edwin Schmierer]
 tags: ['Data Privacy']
 description: "We look at the state of play in data privacy regulations and how business and tech leaders can adapt."
 profile: img/team/edwin-schmierer.png

--- a/content/en/blog/2021-10-01-introducing-whisper.md
+++ b/content/en/blog/2021-10-01-introducing-whisper.md
@@ -4,7 +4,7 @@ slug: "introducing-whisper"
 date: 2021-10-01T16:32:47-04:00
 draft: false
 image: img/blog/whispering_wheat.jpg
-author: Edwin Schmierer
+authors: [Edwin Schmierer]
 tags: ['Security']
 description: "Shhh..there's a better way to share secrets. Introducing Whisper, our secret-sharing utility."
 profile: img/team/edwin-schmierer.png

--- a/content/en/blog/2021-10-22-why-devs-dont-translate.md
+++ b/content/en/blog/2021-10-22-why-devs-dont-translate.md
@@ -4,7 +4,7 @@ slug: "why-devs-dont-translate"
 date: "2021-10-21T20:25:35-04:00"
 draft: false
 image: img/blog/hubble_tarantula_nebula.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 tags: ['i18n']
 description: "Many tech projects do not translate their docs, often at the expense of reaching a more global userbase. In this post we explore why."
 profile: img/team/rebecca-bilbro.png

--- a/content/en/blog/2021-11-14-predicting-star-ratings.md
+++ b/content/en/blog/2021-11-14-predicting-star-ratings.md
@@ -4,7 +4,7 @@ slug: "predicting-star-ratings"
 date: 2021-11-14T10:40:29-04:00
 draft: false
 image: img/blog/predicting-stars.jpg
-author: Nabiha Naqvie
+authors: [Nabiha Naqvie]
 tags: ['AI', 'ML']
 description: "Modern sentiment analysis requires both creativity and elbow grease. In this post, we explore a project to understand Amazon reviews and predict start ratings using open source sentiment analyzers and MongoDB."
 profile: img/team/nabiha-naqvie.png

--- a/content/en/blog/2021-12-06-fake-it-when-you-make-it.md
+++ b/content/en/blog/2021-12-06-fake-it-when-you-make-it.md
@@ -4,7 +4,7 @@ slug: "fake-it-when-you-make-it"
 date: "2021-12-06T10:39:45-06:00"
 draft: false
 image: img/blog/lake_reflection.jpg
-author: Patrick Deziel
+authors: [Patrick Deziel]
 tags: ['Programming', 'Mocks', 'Golang']
 description: "A mock is a common pattern for unit testing interdependent services. In this post we will explore creating mocks in Go."
 profile: img/team/patrick-deziel.png

--- a/content/en/blog/2021-12-07-translation-monitoring-i18n-projects.md
+++ b/content/en/blog/2021-12-07-translation-monitoring-i18n-projects.md
@@ -4,7 +4,7 @@ slug: "trans-monitor-i18n-proj"
 date: 2021-12-07T19:25:35+08:00
 draft: false
 image: img/blog/translations.jpeg
-author: Tianshu Li
+authors: [Tianshu Li]
 tags: ['i18n']
 description: "I18n projects are hard to manage when apps and docs both get updated continuously. In this post we introduce a new tool to ease the pains of monitoring and make it easier to stay in sync with international audiences."
 profile: img/team/tianshu-li.png

--- a/content/en/blog/2022-01-13-data-curation-baleen.md
+++ b/content/en/blog/2022-01-13-data-curation-baleen.md
@@ -4,7 +4,7 @@ slug: "data-curation-baleen"
 date: 2022-01-13T11:37:43-05:00
 draft: false
 image: img/blog/whale.jpg
-author: Nabiha Naqvie
+authors: [Nabiha Naqvie]
 tags: ['Data Engineering']
 description: "Recent developments in Artificial Intelligence (AI) and Natural Language Processing (NLP) indicate a growing need for better mechanisms for collecting curated datasets, and introduces a new open source tool for this purpose."
 profile: img/team/nabiha-naqvie.png

--- a/content/en/blog/2022-04-15-a-gentle-introduction-to-tmux.md
+++ b/content/en/blog/2022-04-15-a-gentle-introduction-to-tmux.md
@@ -4,7 +4,7 @@ slug: "getting-started-with-tmux"
 date: "2022-04-15T09:41:51-07:00"
 draft: false
 image: img/blog/2022-04-15-a-gentle-introduction-to-tmux/muxing.jpg
-author: Daniel Sollis
+authors: [Daniel Sollis]
 tags: ['Programming']
 description: "Tmux is an extremely powerful terminal solution for Unix-like operating systems, but it has a steep learning curve. In this post we'll go over some Tmux basics and make it a little less daunting to get started."
 profile: img/team/daniel-sollis.png

--- a/content/en/blog/2022-05-04-achieving-total-ordering-with-crdts.md
+++ b/content/en/blog/2022-05-04-achieving-total-ordering-with-crdts.md
@@ -3,7 +3,7 @@ title: "Achieving Total Ordering With CRDTs"
 slug: "achieving-total-ordering-with-crdts"
 date: "2022-05-04T15:02:21-06:00"
 draft: false
-author: Patrick Deziel
+authors: [Patrick Deziel]
 image: img/blog/hourglass.jpg
 tags: ['Distributed Systems']
 description: "Conflict-free replicated data types are starting to take off in popularity, especially in terms of collaborative applications. In this post we will explore how these data structures can be used to achieve a total ordering of events across many peers."

--- a/content/en/blog/2022-05-26-marshaling-go-enums-to-and-from-json.md
+++ b/content/en/blog/2022-05-26-marshaling-go-enums-to-and-from-json.md
@@ -3,7 +3,7 @@ title: "Marshaling Go Enums to and from JSON"
 slug: "marshaling-go-enums-to-and-from-json"
 date: "2022-05-26T08:50:04-05:00"
 draft: false
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 image: img/blog/fireworks_star.jpg
 tags: ['Golang', 'Programming']
 description: "How to customize JSON serialization for your data types while avoiding pointer and receiver problems -- a story in three parts."

--- a/content/en/blog/2022-06-06-six-things-you-didnt-know-about-crypto.md
+++ b/content/en/blog/2022-06-06-six-things-you-didnt-know-about-crypto.md
@@ -3,7 +3,7 @@ title: "6 Things You Didn't Realize about Crypto"
 slug: "six-things-you-didnt-know-about-crypto"
 date: "2022-06-06T09:53:22-05:00"
 draft: false
-author: Edwin Schmierer & Rebecca Bilbro
+authors: ['Edwin Schmierer', 'Rebecca Bilbro']
 image: img/blog/viking_runes.jpg
 tags: ['Crypto']
 description: "This post describes some of the most important facts about cryptocurrency that people don't often understand -- including crypto people!"

--- a/content/en/blog/2022-06-20-five-technologies-quietly-transforming-the-web.md
+++ b/content/en/blog/2022-06-20-five-technologies-quietly-transforming-the-web.md
@@ -3,7 +3,7 @@ title: "Five Technologies Quietly Transforming the Web"
 slug: "five-technologies-quietly-transforming-the-web"
 date: "2022-06-27T13:00:01-04:00"
 draft: false
-author: Edwin Schmierer
+authors: [Edwin Schmierer]
 image: img/blog/dawn.jpg
 tags: ['WASM', 'AI', 'ML', 'gRPC', 'Microservices']
 description: "This post describes five technologies - new and old - that are transforming the web and becoming the foundation for next-generation applications."

--- a/content/en/blog/2022-07-08-transparently-mocking-grpc-services.md
+++ b/content/en/blog/2022-07-08-transparently-mocking-grpc-services.md
@@ -3,7 +3,7 @@ title: "Transparently Mocking gRPC Services"
 slug: "transparently-mocking-grpc-services"
 date: "2022-07-08T09:32:01-04:00"
 draft: false
-author: Patrick Deziel
+authors: [Patrick Deziel]
 image: img/blog/blue_laser.jpg
 tags: ['gRPC', 'Mocks', 'Programming']
 photo_credit: JJ Ying via Unsplash

--- a/content/en/blog/2022-08-08-effective-programmers-read-code.md
+++ b/content/en/blog/2022-08-08-effective-programmers-read-code.md
@@ -3,7 +3,7 @@ title: "Effective Programmers Read Code"
 slug: "effective-programmers-read-code"
 date: "2022-08-08T08:10:14-04:00"
 draft: false
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 image: img/blog/blazes.jpg
 tags: ['Programming']
 description: "While we often think ourselves as authors of code we probably spend more time reading code than writing it. Changing our mindset to think of ourselves as avid code readers will make us more effective programmers."

--- a/content/en/blog/2022-08-15-english-major-interns-in-tech.md
+++ b/content/en/blog/2022-08-15-english-major-interns-in-tech.md
@@ -3,7 +3,7 @@ title: "In Which an English Major Interns in Tech"
 slug: "english-major-interns-in-tech"
 date: "2022-08-15T06:10:14-04:00"
 draft: false
-author: Natasha White
+authors: [Natasha White]
 image: img/blog/paths.jpg
 tags: ['Technology']
 description: "Over the course of the past few months, I’ve had the pleasure of interning at Rotational as a technical writer. I’m excited to share a little bit about my experience and provide some insight from the perspective of someone who is entering the world of distributed systems for the first time."

--- a/content/en/blog/2022-09-07-ranges-of-integer-data-types.md
+++ b/content/en/blog/2022-09-07-ranges-of-integer-data-types.md
@@ -3,7 +3,7 @@ title: "Ranges of Integer Data Types"
 slug: "ranges-of-integer-data-types"
 date: "2022-09-07T09:40:12-05:00"
 draft: false
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 image: img/blog/num215.jpg
 tags: ['Golang', 'Programming']
 profile: img/team/benjamin-bengfort.png

--- a/content/en/blog/2022-09-10-eventing-platforms.md
+++ b/content/en/blog/2022-09-10-eventing-platforms.md
@@ -3,7 +3,7 @@ title: "The Eventing Platform Landscape"
 slug: "eventing-platforms"
 date: "2022-09-10T12:28:08-04:00"
 draft: false
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 image: img/blog/herd.jpg
 tags: ['Microservices', 'Eventing']
 description: "In this post we'll explore some of the types of eventing platforms and discuss why it's not about deciding which is objectively the 'best', but about knowing how to select the best tool for a given context."

--- a/content/en/blog/2022-09-21-eventing-benchmarks.md
+++ b/content/en/blog/2022-09-21-eventing-benchmarks.md
@@ -3,7 +3,7 @@ title: "An Eventing Benchmark Bake-Off"
 slug: "eventing-benchmarks"
 date: "2022-09-10T12:28:08-04:00"
 draft: true
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 image: img/blog/pastries.jpg
 tags: ['Microservices', 'Eventing', 'Programming']
 photo_credit: George Tan via Flickr Commons

--- a/content/en/blog/2022-09-23-why-webassembly-is-the-future-of-computing.md
+++ b/content/en/blog/2022-09-23-why-webassembly-is-the-future-of-computing.md
@@ -3,7 +3,7 @@ title: "Why WebAssembly Is the Future of Computing"
 slug: "webassembly-the-future-of-computing"
 date: "2022-09-27T08:51:27-04:00"
 draft: false
-author: Danielle Maxwell
+authors: [Danielle Maxwell]
 image: img/blog/rocket.jpeg
 tags: ['WASM']
 description: "Learn about WebAssembly, how it is currently transforming web development, and why its future is bright."

--- a/content/en/blog/2022-10-31-october-retreats-and-conferences.md
+++ b/content/en/blog/2022-10-31-october-retreats-and-conferences.md
@@ -4,7 +4,7 @@ slug: "october-retreats-and-conferences"
 date: "2022-10-31T13:32:04-05:00"
 draft: false
 image: img/blog/2022-10-31-willis-tower.jpg
-author: "Benjamin Bengfort"
+authors: [Benjamin Bengfort]
 profile: img/team/benjamin-bengfort.png
 tags: ['News', 'Company']
 photo_credit: Photo by Cody Engel on Unsplash

--- a/content/en/blog/2022-11-29-twitter-wont-disappear-overnight.md
+++ b/content/en/blog/2022-11-29-twitter-wont-disappear-overnight.md
@@ -4,7 +4,7 @@ slug: "twitter-wont-disappear-overnight"
 date: "2022-11-29T16:52:09-05:00"
 draft: false
 image: img/blog/2022-11-29-storm-clouds.jpg
-author: "Edwin Schmierer"
+authors: [Edwin Schmierer]
 profile: img/team/edwin-schmierer.png
 tags: ['Distributed Systems']
 photo_credit: Photo by Drew Hays on Unsplash

--- a/content/en/blog/2022-12-05-go-serialization-formats.md
+++ b/content/en/blog/2022-12-05-go-serialization-formats.md
@@ -4,7 +4,7 @@ slug: "go-serialization-formats"
 date: "2022-12-05T10:27:11-05:00"
 draft: false
 image: img/blog/serialization.png
-author: Daniel Sollis & Danielle Maxwell
+authors: ['Daniel Sollis', 'Danielle Maxwell']
 tags: ['Serialization']
 photo_credit: Photo by Rickie-Tom Schünemann on Unsplash
 description: "In this post we’ll go over a few important serialization formats along with their pros and cons to help you determine the best choice for your situation."

--- a/content/en/blog/2022-12-19-building-a-raft-part-1.md
+++ b/content/en/blog/2022-12-19-building-a-raft-part-1.md
@@ -4,7 +4,7 @@ slug: "building-a-raft-part-1"
 date: "2022-12-19T17:14:04-05:00"
 draft: false
 image: img/blog/2022-12-19-building-a-raft-part-1/otterRaftOne.png
-author: "Daniel Sollis"
+authors: [Daniel Sollis]
 tags: ['Distributed Systems']
 profile: img/team/daniel-sollis.png
 description: "In the first part of our series on the Raft consensus algorithm we'll give an overview and introduction of the algorithm."

--- a/content/en/blog/2022-12-23-distrupting-managed-services.md
+++ b/content/en/blog/2022-12-23-distrupting-managed-services.md
@@ -4,7 +4,7 @@ slug: "disrupt-managed-services"
 date: "2022-12-23T11:43:15-05:00"
 draft: false
 image: img/blog/dandelion.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 tags: ['Managed Services']
 photo_credit: Photo by unbekannt270 from Flickr
 description: "In this post, we introduce three trends that are poised to disrupt managed service offerings in 2023 and beyond."

--- a/content/en/blog/2023-01-10-building-a-raft-part-2.md
+++ b/content/en/blog/2023-01-10-building-a-raft-part-2.md
@@ -4,7 +4,7 @@ slug: "building-a-raft-part-2"
 date: "2023-01-10T09:55:04-05:00"
 draft: false
 image: img/blog/2023-01-10-building-a-raft-part-2/otterRaftTwo.png
-author: "Daniel Sollis"
+authors: ["Daniel Sollis"]
 tags: ['Distributed Systems']
 profile: img/team/daniel-sollis.png
 description: "In the second part of our series on the Raft consensus algorithm we'll be covering log replication."

--- a/content/en/blog/2023-01-21-prototyping-eda-with-watermill.md
+++ b/content/en/blog/2023-01-21-prototyping-eda-with-watermill.md
@@ -5,7 +5,7 @@ date: "2023-01-21T11:13:46-05:00"
 draft: false
 image: img/blog/watermill.jpg
 photo_credit: Photo by Terence Mangram on Flickr Commons
-author: Prema Roman
+authors: [Prema Roman]
 tags: ['Microservices', 'Eventing']
 profile: img/team/prema-roman.png
 description: "An introduction to using the Watermill API to enable rapid prototyping for event-driven architectures."

--- a/content/en/blog/2023-02-07-building-a-raft-part-3.md
+++ b/content/en/blog/2023-02-07-building-a-raft-part-3.md
@@ -4,7 +4,7 @@ slug: "building-a-raft-part-3"
 date: "2023-02-14T12:24:32-05:00"
 draft: false
 image: img/blog/2023-02-07-building-a-raft-part-3/otterRaftThree.png
-author: "Daniel Sollis"
+authors: ["Daniel Sollis"]
 tags: ['Distributed Systems']
 profile: img/team/daniel-sollis.png
 description: "In the third and final part of our series on the Raft consensus algorithm we'll wrap up by going over leader election."

--- a/content/en/blog/2023-03-09-wrangling-cattle-and-engineers.md
+++ b/content/en/blog/2023-03-09-wrangling-cattle-and-engineers.md
@@ -5,7 +5,7 @@ date: "2023-03-09T16:11:27-05:00"
 draft: false
 image: img/blog/home-on-the-range.jpg
 photo_credit: Photo by Amaury Laporte on Flickr Commons
-author: "Beci Lambrecht"
+authors: ["Beci Lambrecht"]
 tags: ['Project Management']
 profile: img/team/beci-lambrecht.png
 description: "Wrangling cattle and doing technical project management are strangely similar."

--- a/content/en/blog/2023-03-17-double-checked-locking.md
+++ b/content/en/blog/2023-03-17-double-checked-locking.md
@@ -4,7 +4,7 @@ slug: "double-checked-locking"
 date: "2023-03-17T12:31:07-05:00"
 draft: false
 image: img/blog/clover-blanket.jpg
-author: Benjamin Bengfort & Prema Roman
+authors: ['Benjamin Bengfort', 'Prema Roman']
 tags: ['Concurrency']
 profile: img/butterfly.png
 photo_credit: "Photo by Timothy Dykes on Unsplash"

--- a/content/en/blog/2023-03-21-introducing-ensign.md
+++ b/content/en/blog/2023-03-21-introducing-ensign.md
@@ -4,7 +4,7 @@ slug: "introducing-ensign"
 date: "2023-03-21T10:32:35-04:00"
 draft: false
 image: img/blog/supernova.jpg
-author: "Edwin Schmierer"
+authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ['News', 'Company', 'Eventing']
 photo_credit: Photo by Smithsonian Institution via Flickr Commons

--- a/content/en/blog/2023-03-24-mastering-the-art-of-data-freshness.md
+++ b/content/en/blog/2023-03-24-mastering-the-art-of-data-freshness.md
@@ -4,7 +4,7 @@ slug: "mastering-the-art-of-data-freshness"
 date: "2023-03-24T10:34:25-04:00"
 draft: false
 image: img/blog/ripe-pears.jpg
-author: "Edwin Schmierer"
+authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ['Eventing', 'Flexstreams']
 photo_credit: Photo by Oleksandr K (oleksandr_k) via Flickr Commons

--- a/content/en/blog/2023-03-28-mocking-the-universe.md
+++ b/content/en/blog/2023-03-28-mocking-the-universe.md
@@ -4,7 +4,7 @@ slug: "mocking-the-universe"
 date: "2023-03-28T13:29:11-04:00"
 draft: false
 image: img/blog/2023-03-08-mocking-the-universe/monkey-in-mirror.jpg
-author: Daniel Sollis
+authors: [Daniel Sollis]
 tags: ['Golang', 'Programming', 'Testing', 'gRPC']
 profile: img/team/daniel-sollis.png
 description: "Mocking can be an easy way to get around gRPC connections when testing."

--- a/content/en/blog/2023-04-01-ensign-for-enterprise-ai.md
+++ b/content/en/blog/2023-04-01-ensign-for-enterprise-ai.md
@@ -4,7 +4,7 @@ slug: "ensign-for-enterprise-ai"
 date: "2023-04-01T07:29:49-04:00"
 draft: false
 image: img/blog/bridgerace.jpg
-author: "Edwin Schmierer"
+authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ['AI', 'Automation']
 photo_credit: Metropolitan Transportation Authority via Flickr Commons

--- a/content/en/blog/2023-04-18-rereading-chatgpt.md
+++ b/content/en/blog/2023-04-18-rereading-chatgpt.md
@@ -4,7 +4,7 @@ slug: "rereading-chatgpt"
 date: "2023-04-18T09:38:32-04:00"
 draft: false
 image: img/blog/power-lines.jpg
-author: Jennifer Lieberman
+authors: [Jennifer Lieberman]
 tags: ['AI', 'ML', 'Automation']
 profile: img/butterfly.png
 description: "A Humanities professor offers some unexpected new perspectives on ChatGPT inspired by the American Realism literary tradition."

--- a/content/en/blog/2023-05-05-esg-is-a-data-problem.md
+++ b/content/en/blog/2023-05-05-esg-is-a-data-problem.md
@@ -4,7 +4,7 @@ slug: "esg-is-a-data-problem"
 date: "2023-05-05T14:09:40-04:00"
 draft: false
 image: img/blog/light-through-trees.jpg
-author: "Edwin Schmierer"
+authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ['ESG', 'Ensign', 'Eventing']
 photo_credit: Christian Buehner via Unsplash

--- a/content/en/blog/2023-05-09-age-of-postsql.md
+++ b/content/en/blog/2023-05-09-age-of-postsql.md
@@ -4,7 +4,7 @@ slug: "age-of-postsql"
 date: "2023-05-09T09:44:57-04:00"
 draft: false
 image: img/blog/postmodern.jpg
-author: Rebecca Bilbro
+authors: [Rebecca Bilbro]
 tags: ['Databases', 'Eventing']
 photo_credit: Photo by Bervaz via Flickr Commons
 description: "Messiness is the norm for data, not the exception. Let's stop searching for the 'one true' database and just pick tools that help us get the job done."

--- a/content/en/blog/2023-05-23-what-are-microfrontends.md
+++ b/content/en/blog/2023-05-23-what-are-microfrontends.md
@@ -5,7 +5,7 @@ date: "2023-05-23T13:24:42-04:00"
 draft: false
 image: img/blog/2023-05-29/puzzle-pieces.jpg
 photo_credit: Photo by Hans-Peter Gauster via Unsplash
-author: Danielle Maxwell
+authors: [Danielle Maxwell]
 profile: img/team/danielle-maxwell.png
 tags: ['Frontend', 'Microfrontend']
 description: "Micro-frontends could be the ideal solution if your monolithic frontend is causing growing pains."

--- a/content/en/blog/2023-05-26-real-time-processing.md
+++ b/content/en/blog/2023-05-26-real-time-processing.md
@@ -5,7 +5,7 @@ date: "2023-05-26T09:00:00-04:00"
 draft: false
 image: img/blog/starburst.jpg
 photo_credit: Photo by Joshua Sortino on Unsplash
-author: Faraz Rahman
+authors: [Faraz Rahman]
 profile: img/butterfly.png
 tags: ['Eventing', 'AI', 'ML']
 description: "A data product manager shares tips for achieving success with streaming data."

--- a/content/en/blog/2023-06-05-async-or-swim.md
+++ b/content/en/blog/2023-06-05-async-or-swim.md
@@ -5,7 +5,7 @@ date: "2023-06-05T10:39:51-05:00"
 draft: false
 image: img/blog/mississippi.jpg
 photo_credit: Photo by USGS on Unsplash
-author: Patrick Deziel
+authors: [Patrick Deziel]
 profile: img/team/patrick-deziel.png
 tags: ['Eventing', 'Golang']
 description: "A technical dive into asynchronous processing in Go."

--- a/content/en/blog/2023-06-08-startup-strategies.md
+++ b/content/en/blog/2023-06-08-startup-strategies.md
@@ -5,7 +5,7 @@ date: "2023-06-08T19:15:26-04:00"
 draft: false
 image: img/blog/balloons.jpg
 photo_credit: Photo by Patrick Down on Flickr Commons
-author: Beci Lambrecht
+authors: [Beci Lambrecht]
 profile: img/team/beci-lambrecht.png
 tags: ['Startups']
 description: "What does it feel like to work at a startup?"

--- a/content/en/blog/2023-07-11-mlops-through-eventing.md
+++ b/content/en/blog/2023-07-11-mlops-through-eventing.md
@@ -5,7 +5,7 @@ date: "2023-07-11T15:22:29-04:00"
 draft: false
 image: img/blog/airshow.jpg
 photo_credit: Photo by Johannes Tandl via Flickr Commons
-author: Rotational Labs
+authors: [Rotational Labs]
 profile: img/butterfly.png
 tags: ['MLOps', 'Eventing', 'AI', 'ML']
 description: "If MLOps is an afterthought in your usual ML workflow, its time to start thinking in events."

--- a/content/en/blog/2023-07-13-building-an-nlp-event-driven-app.md
+++ b/content/en/blog/2023-07-13-building-an-nlp-event-driven-app.md
@@ -5,7 +5,7 @@ date: "2023-07-13T16:45:10-04:00"
 draft: false
 image: img/blog/victory.jpg
 photo_credit: Photo by Zion National Park via Flickr Commons
-author: Aatmaj Janardanan
+authors: [Aatmaj Janardanan]
 profile: img/team/aatmaj-janardanan.png
 tags: ['NLP', 'AI', 'ML', 'Eventing']
 description: "Rotational's summer intern shares challenges and victories encountered when developing his first event-driven data science app!"

--- a/content/en/blog/2023-07-30-speeding-up-go-tests.md
+++ b/content/en/blog/2023-07-30-speeding-up-go-tests.md
@@ -5,7 +5,7 @@ date: "2023-07-30T09:39:09-05:00"
 draft: false
 image: img/blog/footrace.jpg
 photo_credit: "Photo by Braden Collum on Unsplash"
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 profile: img/team/benjamin-bengfort.png
 tags: ['Golang']
 description: "By using parallel and short modes with Go tests, we can improve our local test speed and save longer running tests for CI."

--- a/content/en/blog/2023-08-01-streaming-nlp-with-llms-and-ensign.md
+++ b/content/en/blog/2023-08-01-streaming-nlp-with-llms-and-ensign.md
@@ -5,7 +5,7 @@ date: "2023-08-01T12:56:58-04:00"
 draft: false
 image: img/blog/egret-and-buffalo.jpg
 photo_credit: Photo by Francesco Veronesi via Flickr Commons
-author: Rotational Labs
+authors: [Rotational Labs]
 profile: img/butterfly.png
 tags: ['MLOps', 'Eventing', 'AI', 'ML']
 description: "Walk through the end-to-end process of building a streaming sentiment analysis application using a HuggingFace LLM and Ensign for real time predictions."

--- a/content/en/blog/2023-08-01-streaming-nlp-with-llms-and-ensign.md
+++ b/content/en/blog/2023-08-01-streaming-nlp-with-llms-and-ensign.md
@@ -21,7 +21,7 @@ Sound familiar? This is for anyone out there who knows they have a good use case
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/7hXMpwS86Ro?start=331" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-🎥 You can also watch an [on-demand recording of this tutorial](https://www.youtube.com/watch?v=7hXMpwS86Ro&t=331s), delivered by Rotational Labs Distributed Systems Engineer, [Prema Roman](https://rotational.io/bio/prema-roman/).
+🎥 You can also watch an [on-demand recording of this tutorial](https://www.youtube.com/watch?v=7hXMpwS86Ro&t=331s), delivered by Rotational Labs Distributed Systems Engineer, [Prema Roman](https://rotational.io/authors/prema-roman/).
 
 😎 Just here for Prema's code? [Here's the repo](https://github.com/rotationalio/huggingface-example)!
 

--- a/content/en/blog/2023-08-11-realtime-machine-learning.md
+++ b/content/en/blog/2023-08-11-realtime-machine-learning.md
@@ -5,7 +5,7 @@ date: "2023-08-11T15:19:00-04:00"
 draft: false
 image: img/blog/2023-08-07-realtime-machine-learning/bird-fly-unsplash.jpg
 photo_credit: Photo by Navi on Unsplash
-author: Prema Roman
+authors: [Prema Roman]
 profile: img/team/prema-roman.png
 tags: ['NLP', 'AI', 'ML', 'Eventing']
 description: "It's time to rethink how machine learning is done. Switching to real-time machine learning enables companies to easily adapt in a world where change is the only constant."

--- a/content/en/blog/2023-08-21-what-is-incremental-learning.md
+++ b/content/en/blog/2023-08-21-what-is-incremental-learning.md
@@ -5,7 +5,7 @@ date: "2023-08-21T10:17:03-04:00"
 draft: false
 image: img/blog/festival-lights.jpg
 photo_credit: Photo by Viaggio Routard via Flickr Commons
-author: Aatmaj Janardanan
+authors: [Aatmaj Janardanan]
 profile: img/team/aatmaj-janardanan.png
 tags: ['NLP', 'AI', 'ML', 'Eventing']
 description: "Incremental learning, and other real time machine learning techniques, are an excellent addition to the standard data science toolkit."

--- a/content/en/blog/2023-08-22-introduction-to-polars.md
+++ b/content/en/blog/2023-08-22-introduction-to-polars.md
@@ -5,7 +5,7 @@ date: "2023-08-22T09:32:37-04:00"
 draft: false
 image: img/blog/2023-08-18-introduction-to-polars/polar-bears-unsplash.jpg
 photo_credit: Photo by Hans-Jurgen Mager on Unsplash
-author: Prema Roman
+authors: [Prema Roman]
 profile: img/team/prema-roman.png
 tags: ['Python', 'Data']
 description: "Love Pandas? Check out this overview of Polars - the new high-performance Python data processing library."

--- a/content/en/blog/2023-09-01-year-one-lessons.md
+++ b/content/en/blog/2023-09-01-year-one-lessons.md
@@ -5,7 +5,7 @@ date: "2023-09-01T07:22:43-04:00"
 draft: false
 image: img/blog/2023-09-01-year-one-lessons/fireworks.jpg
 photo_credit: Photo by DESIGNECOLOGIST on Unsplash
-author: Danielle Maxwell
+authors: [Danielle Maxwell]
 profile: img/team/danielle-maxwell.png
 tags: ['Programming', 'Career']
 description: After spending my first year as a junior developer at Rotational Labs, it's time to reflect on some lessons learned along the way.

--- a/content/en/blog/2023-09-14-how-to-dockerize-data-science-processes.md
+++ b/content/en/blog/2023-09-14-how-to-dockerize-data-science-processes.md
@@ -5,7 +5,7 @@ date: "2023-09-14T11:52:15-05:00"
 draft: false
 image: img/blog/2023-09-14-dockerize-data-science/container.webp
 photo_credit: "Photo by Venti Views on Unsplash"
-author: Benjamin Bengfort
+authors: [Benjamin Bengfort]
 profile: img/team/benjamin-bengfort.png
 tags: ["Docker", "Data Science", "Python"]
 description: "Docker is good for containerizing jobs and services, but most tutorials focus on web apps and microservices. This post is for data scientists! It contains a Python Dockerfile to use as a reference when creating your containers with scientific and numeric computing dependencies for data transformations, ETLs, inferencing, and other statistical analyses."

--- a/content/en/blog/2023-09-27-uchicago-hackathon.md
+++ b/content/en/blog/2023-09-27-uchicago-hackathon.md
@@ -5,7 +5,7 @@ date: "2023-09-27T08:04:58-07:00"
 draft: false
 image: img/blog/autumn_leaves.jpg
 photo_credit: "Hiro via Flickr Commons"
-author: "Edwin Schmierer"
+authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ["Hackathon", "Data Science", "Python"]
 description: "Rotational Labs is excited to announce our partnership and hackathon with the University of Chicago Data Science Institute! "

--- a/data/en/team.yml
+++ b/data/en/team.yml
@@ -112,7 +112,7 @@ team:
           link : "https://www.linkedin.com/in/daniellemaxwell"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/daniellemaxwell"
-      bioLink: 'bio/danielle-maxwell'
+      bioLink: 'authors/danielle-maxwell'
     # team member loop
     - name : Pete Keleher
       image : img/team/pete-keleher.png

--- a/data/en/team.yml
+++ b/data/en/team.yml
@@ -15,7 +15,7 @@ team:
           link : "https://twitter.com/bbengfort"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/bbengfort"
-      bioLink : bio/benjamin-bengfort
+      bioLink : authors/benjamin-bengfort
 
     # team member loop
     - name : Rebecca Bilbro
@@ -29,7 +29,7 @@ team:
           link : "https://twitter.com/rebeccabilbro"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/rebeccabilbro"
-      bioLink : bio/rebecca-bilbro
+      bioLink : authors/rebecca-bilbro
     # team member loop
     - name : Edwin Schmierer
       image : img/team/edwin-schmierer.png
@@ -42,7 +42,7 @@ team:
           link : "https://twitter.com/eschmierer"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/eschmier"
-      bioLink : bio/edwin-schmierer
+      bioLink : authors/edwin-schmierer
     # team member loop
     - name : Amanda Stanley
       image : img/team/amanda-stanley.png
@@ -51,7 +51,7 @@ team:
       social :
         - icon : "ti-linkedin" # themify icon pack : https://themify.me/themify-icons
           link : "https://www.linkedin.com/in/stanleyamandak/"
-      bioLink: 'bio/amanda-stanley'
+      bioLink: 'authors/amanda-stanley'
     # team member loop
     - name : Patrick Deziel
       image : img/team/patrick-deziel.png
@@ -64,7 +64,7 @@ team:
           link : "https://twitter.com/PatrickDeziel"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/pdeziel"
-      bioLink: 'bio/patrick-deziel'
+      bioLink: 'authors/patrick-deziel'
     # team member loop
     - name : Prema Roman
       image : img/team/prema-roman.png
@@ -75,13 +75,13 @@ team:
           link : "https://www.linkedin.com/in/premaroman/"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/pdamodaran"
-      bioLink: 'bio/prema-roman'
+      bioLink: 'authors/prema-roman'
     # team member loop
     - name : Beci Lambrecht
       image : img/team/beci-lambrecht.png
       designation : Project Management Support
       content : Certified PMP & Agile Specialist
-      bioLink: 'bio/beci-lambrecht'
+      bioLink: 'authors/beci-lambrecht'
     # team member loop
     - name : Daniel Sollis
       image : img/team/daniel-sollis.png
@@ -92,7 +92,7 @@ team:
           link : "https://www.linkedin.com/in/daniel-sollis-67481114a/"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/DanielSollis"
-      bioLink: 'bio/daniel-sollis'
+      bioLink: 'authors/daniel-sollis'
     # team member loop
     - name : Cletus Razakou
       image : img/team/cletus-razakou.png
@@ -101,7 +101,7 @@ team:
       social :
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/masskoder"
-      bioLink: 'bio/cletus-razakou'
+      bioLink: 'authors/cletus-razakou'
     # team member loop
     - name : Danielle Maxwell
       image : img/team/danielle-maxwell.png
@@ -121,7 +121,7 @@ team:
       social :
         - icon : "ti-linkedin" # themify icon pack : https://themify.me/themify-icons
           link : "https://www.linkedin.com/in/pete-keleher-a03639b"
-      bioLink: 'bio/pete-keleher'
+      bioLink: 'authors/pete-keleher'
 
     # team member loop
     - name : Aatmaj Janardanan
@@ -133,7 +133,7 @@ team:
           link : "https://www.linkedin.com/in/aatmaj-janardanan-104216140/"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/Aatmaj1"
-      bioLink: 'bio/aatmaj-janardanan'
+      bioLink: 'authors/aatmaj-janardanan'
     # team member loop
     - name : Natasha White
       image : img/team/natasha-white.png
@@ -142,7 +142,7 @@ team:
       social :
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/nwhite222"
-      bioLink: 'bio/natasha-white'
+      bioLink: 'authors/natasha-white'
     # team member loop
     - name : Nabiha Naqvie
       image : img/team/nabiha-naqvie.png
@@ -153,7 +153,7 @@ team:
           link : "https://www.linkedin.com/in/nabiha-naqvie-22765612a/"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/nabihanaqvie"
-      bioLink: 'bio/nabiha-naqvie'
+      bioLink: 'authors/nabiha-naqvie'
       # team member loop
     - name : Karen Belita
       image : img/team/karen-belita.png
@@ -164,7 +164,7 @@ team:
           link : "https://www.linkedin.com/in/karenbelita/"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/kbelita"
-      bioLink: 'bio/karen-belita'
+      bioLink: 'authors/karen-belita'
     # team member loop
     - name : Tianshu Li
       image : img/team/tianshu-li.png
@@ -175,7 +175,7 @@ team:
           link : "https://www.linkedin.com/in/tianshu-li-5b5563b0/"
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/tl6kk"
-      bioLink: 'bio/tianshu-li'
+      bioLink: 'authors/tianshu-li'
     # team member loop
     - name : Elysee Bleu
       image : img/team/elysee-bleu.png
@@ -184,4 +184,4 @@ team:
       social :
         - icon : "ti-github" # themify icon pack : https://themify.me/themify-icons
           link : "https://github.com/elysee15"
-      bioLink: 'bio/elysee-bleu'
+      bioLink: 'authors/elysee-bleu'

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -23,7 +23,9 @@
         <div class="flex justify-between items-center px-6 py-3 border-t mt-6">
             <div class="flex items-center">
                 <img src="{{ .Params.profile }}" alt="" class="rounded-full h-10 w-10">
-                <span class="ml-4 font-extralight">{{ .Params.author }}</span>
+                {{ range .Params.authors }}
+                <span class="ml-4 font-extralight"><a href="/authors/{{ . | urlize }}">{{ . }}</a></span>
+                {{ end }}
             </div>
             <div class="font-extralight">
                 {{ dateFormat "Jan 2, 2006" .Date }}

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -15,9 +15,14 @@ relative bg-[#1D65A6]">
 
 <div class="max-w-7xl mx-auto px-4 my-auto relative">
     <div class="flex basis-3 items-start py-4 md:p-16 flex-col md:flex-row">
+        {{ if .Params.name }}
         <div class="w-full md:w-1/2">
             <div class="">
+                {{ if .Params.profile }}
                 <img src="{{ .Params.profile | absURL}}" alt="" class='rounded-t-xl covatar w-full object-cover' />
+                {{ else }}
+                <img src="/img/butterfly.png" alt=""  />
+                {{ end }}
             </div>
             <div class="mt-4 w-full md:mt-8">
                 <h1 class="text-base font-semibold text-sky-800">{{ .Params.field }}</h1>
@@ -38,11 +43,19 @@ relative bg-[#1D65A6]">
                 {{ end }}
             </ul>
         </div>
+        
     </div>
+    {{ end }}
+    
+    {{ if .Data.Pages }}
     <div class="mt-8 md:mt-0 md:ml-16">
+        {{ if .Params.name }}
         <h2 class="text-xl font-bold text-sky-900 sm:mb-8">Blog Posts Written by {{ with .Params.name }} {{ index (split . " ") 0 | safeHTML }} {{ end }}</h2>
+        {{ else }}
+        <h2 class="text-xl font-bold text-sky-900 sm:mb-8">Blog Posts Written by {{ .Title }} </h2>
+        {{ end }}
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
-            {{ $paginator := .Paginate .Data.Pages }}
+            {{ $paginator := .Paginate .Data.Pages 6 }}
             {{ range $paginator.Pages }}
             <li class="mt-6 sm:mt-0 h-auto">
                 {{ .Render "article" }}
@@ -51,9 +64,9 @@ relative bg-[#1D65A6]">
 
         </ul>
 
-
         {{ partial "paginator.html" . }}
 
     </div>
+    {{ end }}
 </div>
 {{ end }}

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -39,8 +39,21 @@ relative bg-[#1D65A6]">
             </ul>
         </div>
     </div>
-    <div>
-        <h2 class="text-xl font-bold text-sky-900 my-2 md:my-4 ">Blog Posts</h2>
+    <div class="mt-8 md:mt-0 md:ml-16">
+        <h2 class="text-xl font-bold text-sky-900 sm:mb-8">Blog Posts Written by {{ with .Params.name }} {{ index (split . " ") 0 | safeHTML }} {{ end }}</h2>
+        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
+            {{ $paginator := .Paginate .Data.Pages }}
+            {{ range $paginator.Pages }}
+            <li class="mt-6 sm:mt-0 h-auto">
+                {{ .Render "article" }}
+            </li>
+            {{ end }}
+
+        </ul>
+
+
+        {{ partial "paginator.html" . }}
+
     </div>
 </div>
 {{ end }}

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -1,0 +1,46 @@
+{{ define "name" }}
+{{ .Title }} &ndash; {{ .Site.Title }}
+{{ end }}
+
+
+{{ define "header" }}
+<div class="sm:pt-5 
+
+relative bg-[#1D65A6]">
+    {{ partial "site-nav.html" . }}
+</div>
+{{ end }}
+
+{{ define "main" }}
+
+<div class="max-w-7xl mx-auto px-4 my-auto relative">
+    <div class="flex basis-3 items-start py-4 md:p-16 flex-col md:flex-row">
+        <div class="w-full md:w-1/2">
+            <div class="">
+                <img src="{{ .Params.profile | absURL}}" alt="" class='rounded-t-xl covatar w-full object-cover' />
+            </div>
+            <div class="mt-4 w-full md:mt-8">
+                <h1 class="text-base font-semibold text-sky-800">{{ .Params.field }}</h1>
+                <h1 class="mt-2 text-2xl font-bold text-black md:mt-4">{{ .Params.name }}</h1>
+                <h1 class="mt-2 text-base text-gray-400 md:mt-4">{{ .Params.designation }}</h1>
+            </div>
+        </div>
+        <div class="flex flex-col md:pl-5 w-full md:w-1/2">
+            <h1 class="text-xl font-bold text-sky-900 my-2 md:my-4 ">Bio</h1>
+            <div class="w-full mx-auto prose prose-blue">{{ .Content | safeHTML }}</div>
+            <ul class="mt-4 flex w-full gap-8 md:mt-6">
+                {{ range .Params.social }}
+                <li><a href="{{ .link | absURL }}" target="_blank"
+                        class="flex w-16 h-16 items-center  rounded-lg bg-sky-900 text-white">
+                        <i class="fab {{ .icon }} text-2xl mx-auto"></i>
+                    </a>
+                </li>
+                {{ end }}
+            </ul>
+        </div>
+    </div>
+    <div>
+        <h2 class="text-xl font-bold text-sky-900 my-2 md:my-4 ">Blog Posts</h2>
+    </div>
+</div>
+{{ end }}

--- a/layouts/authors/terms.html
+++ b/layouts/authors/terms.html
@@ -1,0 +1,6 @@
+<h1>Authors</h1>
+<ul>
+{{ range .Data.Pages }}
+  <li><a href="{{ .Permalink }}">{{ .Params.name }}</a></li>
+{{ end }}
+</ul>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -26,7 +26,9 @@
       </h3>
       <div class="flex flex-wrap justify-center items-center my-4">
         <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
-          <span class="ml-3 blog-date">{{ .Params.author }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
+        {{ range .Params.authors }}
+          <span class="ml-3 blog-date"><a href="/authors/{{ . | urlize }}">{{ . }}</a>  {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
+         
           <ul class="flex whitespace-nowrap">
             {{ range .Params.tags }}
             <li class="blog-tag"><a href="/tags/{{ . | urlize }}"> {{ . }}</a></li>
@@ -55,7 +57,7 @@
           {{ i18n "writtenBy" }}:</h2>
         <div class="flex items-center justify-center">
           <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full drop-shadow-lg w-14 h-14">
-          <span class="lg:w-[20ch] mx-2">{{ .Params.author }}</span>
+          <span class="lg:w-[20ch] mx-2">{{ .Params.authors }}</span>
         </div>
       </div>
       <div class="lg:w-1/2">

--- a/static/output.css
+++ b/static/output.css
@@ -1330,14 +1330,6 @@ video {
   margin-right: 3.5rem;
 }
 
-.ml-16 {
-  margin-left: 4rem;
-}
-
-.ml-28 {
-  margin-left: 7rem;
-}
-
 .block {
   display: block;
 }
@@ -2016,10 +2008,6 @@ video {
   padding: 0.25rem;
 }
 
-.p-16 {
-  padding: 4rem;
-}
-
 .px-6 {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
@@ -2210,10 +2198,6 @@ video {
 
 .pt-10 {
   padding-top: 2.5rem;
-}
-
-.pl-20 {
-  padding-left: 5rem;
 }
 
 .text-left {
@@ -2932,12 +2916,16 @@ em {
     margin-bottom: 2rem;
   }
 
-  .sm\:mt-11 {
-    margin-top: 2.75rem;
+  .sm\:mb-8 {
+    margin-bottom: 2rem;
   }
 
   .sm\:mt-0 {
     margin-top: 0px;
+  }
+
+  .sm\:mt-11 {
+    margin-top: 2.75rem;
   }
 
   .sm\:mt-24 {
@@ -3120,16 +3108,20 @@ em {
     margin-top: 1.5rem;
   }
 
+  .md\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .md\:ml-16 {
+    margin-left: 4rem;
+  }
+
   .md\:mt-7 {
     margin-top: 1.75rem;
   }
 
   .md\:mb-0 {
     margin-bottom: 0px;
-  }
-
-  .md\:mt-0 {
-    margin-top: 0px;
   }
 
   .md\:mt-14 {

--- a/static/output.css
+++ b/static/output.css
@@ -1330,6 +1330,14 @@ video {
   margin-right: 3.5rem;
 }
 
+.ml-16 {
+  margin-left: 4rem;
+}
+
+.ml-28 {
+  margin-left: 7rem;
+}
+
 .block {
   display: block;
 }
@@ -2008,6 +2016,10 @@ video {
   padding: 0.25rem;
 }
 
+.p-16 {
+  padding: 4rem;
+}
+
 .px-6 {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
@@ -2198,6 +2210,10 @@ video {
 
 .pt-10 {
   padding-top: 2.5rem;
+}
+
+.pl-20 {
+  padding-left: 5rem;
 }
 
 .text-left {

--- a/static/output.css
+++ b/static/output.css
@@ -1499,6 +1499,19 @@ video {
   width: 1080px;
 }
 
+.w-fit {
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+.w-28 {
+  width: 7rem;
+}
+
+.w-20 {
+  width: 5rem;
+}
+
 .max-w-7xl {
   max-width: 80rem;
 }


### PR DESCRIPTION
Fixes SC-19502

- Creates authors page for each blog post author
- Displays author bio and blog posts on one page
- Adds link to author's name on blog posts
- Replaces link on team page to direct users to the authors page

Acceptance Criteria:
https://www.awesomescreenshot.com/video/21309206?key=ed09b16251097431d58482ff9d816c66

Note: In the video above, you'll notice that the pages for authors who do not have an `authors` file for them in `content` only displays their blog posts.