### PR TITLE
Increases margin between features header and text

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -17,13 +17,13 @@
                 {{ $header := .Params.header }}
                 {{ with $header }}
                 <div class="mt-6 sm:mt-20">
-                    <h1 class="font-bold text-5xl">{{ . | markdownify }}</h1>
+                    <h1 class="font-bold text-3xl md:text-5xl">{{ . | markdownify }}</h1>
                 </div>
                 {{ end}}
                   {{ $headertext := .Params.headertext }}
                   {{ $headertextmore := .Params.headertextmore }}
                   {{ with $headertext }}
-                  <p class="mt-6 leading-snug sm:leading-tight md:leading-snug xl:leading-tight font-bold">
+                  <p class="mt-6 leading-snug sm:leading-tight md:leading-snug xl:leading-tight text-xl md:text-3xl font-bold">
                       {{ . | markdownify }}
                   </p>
                   {{ if $headertextmore }}

--- a/layouts/shortcodes/features-text.html
+++ b/layouts/shortcodes/features-text.html
@@ -1,1 +1,1 @@
-<p class="mx-4 mt-2 text-left text-lg font-semibold">{{ .Inner | markdownify }}</p>
+<p class="mx-4 mt-4 md:mt-3 text-left text-lg font-semibold">{{ .Inner | markdownify }}</p>

--- a/static/output.css
+++ b/static/output.css
@@ -3132,6 +3132,14 @@ em {
     margin-top: 2.5rem;
   }
 
+  .md\:mt-2 {
+    margin-top: 0.5rem;
+  }
+
+  .md\:mt-3 {
+    margin-top: 0.75rem;
+  }
+
   .md\:flex {
     display: flex;
   }
@@ -3251,6 +3259,16 @@ em {
   .md\:text-lg {
     font-size: 1.125rem;
     line-height: 1.75rem;
+  }
+
+  .md\:text-5xl {
+    font-size: 3rem;
+    line-height: 1;
+  }
+
+  .md\:text-3xl {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
   }
 
   .md\:leading-snug {


### PR DESCRIPTION
Scope of Changes:

- Increases margin between the Ensign features header and text on the home page
- Reduces site header font size on smaller screens

Fixes SC-21741

Acceptance Criteria:
https://www.awesomescreenshot.com/video/21320016?key=74ca1b06137893fba31575574a63dd3d
