### PR TITLE
Adds link to blog post author's name in about this post section

### DIFF
--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -21,10 +21,13 @@
         </div>
 
         <div class="flex justify-between items-center px-6 py-3 border-t mt-6">
-            <div class="flex items-center">
-                <img src="{{ .Params.profile }}" alt="" class="rounded-full h-10 w-10">
+            <div>
+                {{ $profile := .Params.profile }}
                 {{ range .Params.authors }}
-                <span class="ml-4 font-extralight"><a href="/authors/{{ . | urlize }}">{{ . }}</a></span>
+                <a href="/authors/{{ . | urlize }}" class="flex items-center">
+                    <img src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
+                    <span class="ml-4 font-extralight">{{ . }}</span>
+                </a>
                 {{ end }}
             </div>
             <div class="font-extralight">

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -21,13 +21,20 @@
         </div>
 
         <div class="flex justify-between items-center px-6 py-3 border-t mt-6">
-            <div>
+            <div class="flex items-center">
                 {{ $profile := .Params.profile }}
+                {{ if eq (len .Params.authors) 1}}
                 {{ range .Params.authors }}
                 <a href="/authors/{{ . | urlize }}" class="flex items-center">
                     <img src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
                     <span class="ml-4 font-extralight">{{ . }}</span>
                 </a>
+                {{ end }}
+                {{ else }}
+                <img src="{{ .Params.profile }}" alt="" class="rounded-full h-10 w-10">
+                {{ range .Params.authors }}
+                <span class="ml-4 font-extralight"><a href="/authors/{{ . | urlize }}">{{ . }}</a></span>
+                {{ end }}
                 {{ end }}
             </div>
             <div class="font-extralight">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -25,10 +25,12 @@
         {{ with .Title }} {{ after (len (index (split . " ") 0)) . | safeHTML }} {{ end }}
       </h3>
       <div class="flex flex-wrap justify-center items-center my-4">
-        <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
+        {{ $profile := .Params.profile }}
         {{ range .Params.authors }}
-          <span class="ml-3 blog-date"><a href="/authors/{{ . | urlize }}">{{ . }}</a>  {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
-         
+        <a href="/authors/{{ . | urlize }}" class="flex justify-center items-center">
+          <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
+            <span class="ml-3 blog-date">{{ . }} {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
+        </a>
           <ul class="flex whitespace-nowrap">
             {{ range .Params.tags }}
             <li class="blog-tag"><a href="/tags/{{ . | urlize }}"> {{ . }}</a></li>
@@ -55,9 +57,14 @@
       <div class="lg:w-1/2 text-center">
         <h2 class="text-lg text-[#1D65A6] font-bold mb-3">
           {{ i18n "writtenBy" }}:</h2>
-        <div class="flex items-center justify-center">
-          <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full drop-shadow-lg w-14 h-14">
-          <span class="lg:w-[20ch] mx-2">{{ .Params.authors }}</span>
+        <div>
+          {{ $profile := .Params.profile }}
+          {{ range .Params.authors }}
+          <a href="/authors/{{ . | urlize }}" class="flex items-center justify-center">
+          <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full drop-shadow-lg w-14 h-14">
+          <span class="lg:w-[20ch] mx-2">{{ . }}</span>
+          </a>
+          {{ end }}
         </div>
       </div>
       <div class="lg:w-1/2">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -26,11 +26,17 @@
       </h3>
       <div class="flex flex-wrap justify-center items-center my-4">
         {{ $profile := .Params.profile }}
+        {{ if eq (len .Params.authors) 1}}
         {{ range .Params.authors }}
         <a href="/authors/{{ . | urlize }}" class="flex justify-center items-center">
           <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
             <span class="ml-3 blog-date">{{ . }} {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
         </a>
+        {{ else }}
+        <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
+        {{ range .Params.authors }}
+        <span class="ml-3 blog-date"><a href="/authors/{{ . | urlize }}">{{ . }}</a> {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
+        {{ end }}
           <ul class="flex whitespace-nowrap">
             {{ range .Params.tags }}
             <li class="blog-tag"><a href="/tags/{{ . | urlize }}"> {{ . }}</a></li>
@@ -57,13 +63,20 @@
       <div class="lg:w-1/2 text-center">
         <h2 class="text-lg text-[#1D65A6] font-bold mb-3">
           {{ i18n "writtenBy" }}:</h2>
-        <div>
+        <div class="flex items-center">
           {{ $profile := .Params.profile }}
+          {{ if eq (len .Params.authors) 1}}
           {{ range .Params.authors }}
           <a href="/authors/{{ . | urlize }}" class="flex items-center justify-center">
           <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full drop-shadow-lg w-14 h-14">
           <span class="lg:w-[20ch] mx-2">{{ . }}</span>
           </a>
+          {{ end }}
+          {{ else }}
+          <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full drop-shadow-lg w-14 h-14">
+          {{ range .Params.authors }}
+          <span class="lg:w-[20ch] mx-2"><a href="/authors/{{ . | urlize }}">{{ . }}</a></span>
+          {{ end }}
           {{ end }}
         </div>
       </div>

--- a/static/output.css
+++ b/static/output.css
@@ -1499,19 +1499,6 @@ video {
   width: 1080px;
 }
 
-.w-fit {
-  width: -moz-fit-content;
-  width: fit-content;
-}
-
-.w-28 {
-  width: 7rem;
-}
-
-.w-20 {
-  width: 5rem;
-}
-
 .max-w-7xl {
   max-width: 80rem;
 }
@@ -3153,10 +3140,6 @@ em {
     margin-top: 2.5rem;
   }
 
-  .md\:mt-2 {
-    margin-top: 0.5rem;
-  }
-
   .md\:mt-3 {
     margin-top: 0.75rem;
   }
@@ -3277,11 +3260,6 @@ em {
     line-height: 1.75rem;
   }
 
-  .md\:text-lg {
-    font-size: 1.125rem;
-    line-height: 1.75rem;
-  }
-
   .md\:text-5xl {
     font-size: 3rem;
     line-height: 1;
@@ -3290,6 +3268,11 @@ em {
   .md\:text-3xl {
     font-size: 1.875rem;
     line-height: 2.25rem;
+  }
+
+  .md\:text-lg {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
   }
 
   .md\:leading-snug {


### PR DESCRIPTION
Scope of changes:

- Adds link to author's page in the `About This Post` section of a blog post. This also removes the `[ ]` that currently appears around an author's name in that section.
- Makes the blog post author's image clickable.

Fixes SC-21875

Acceptance Criteria:
https://www.awesomescreenshot.com/video/21350496?key=871ed37f420ffdbade7d2cfb4536f90a