### PR TITLE
Wraps names of multiple blog authors

### DIFF
--- a/input.css
+++ b/input.css
@@ -382,3 +382,15 @@ em {
 .blog-tag:first-child::before {
   content: '';
 }
+
+.list-multi-author::after {
+  content: '\00a0&';
+}
+
+.single-multi-author::after {
+  content: '\00a0&\00a0';
+}
+
+.list-multi-author:last-child::after, .single-multi-author:last-child::after {
+  content: '';
+}

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -32,9 +32,11 @@
                 {{ end }}
                 {{ else }}
                 <img src="{{ .Params.profile }}" alt="" class="rounded-full h-10 w-10">
-                {{ range .Params.authors }}
-                <span class="ml-4 font-extralight"><a href="/authors/{{ . | urlize }}">{{ . }}</a></span>
-                {{ end }}
+                <ul class="flex flex-wrap ml-4">
+                    {{ range .Params.authors }}
+                    <li class="list-multi-author font-extralight"><a href="/authors/{{ . | urlize }}">{{ . }}</a></li>
+                    {{ end }}
+                </ul>
                 {{ end }}
             </div>
             <div class="font-extralight">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -28,20 +28,24 @@
         {{ $profile := .Params.profile }}
         {{ if eq (len .Params.authors) 1}}
         {{ range .Params.authors }}
-        <a href="/authors/{{ . | urlize }}" class="flex justify-center items-center">
-          <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
-            <span class="ml-3 blog-date">{{ . }} {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
+        <a href="/authors/{{ . | urlize }}">
+          <img src="{{ $profile }}" alt="" class="mr-3 border-4 border-white rounded-full h-11 drop-shadow-lg">
         </a>
-        {{ else }}
-        <img src="{{ .Params.profile }}" alt="" class="border-4 border-white rounded-full h-11 drop-shadow-lg">
-        {{ range .Params.authors }}
-        <span class="ml-3 blog-date"><a href="/authors/{{ . | urlize }}">{{ . }}</a> {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp; </span>
         {{ end }}
-          <ul class="flex whitespace-nowrap">
-            {{ range .Params.tags }}
-            <li class="blog-tag"><a href="/tags/{{ . | urlize }}"> {{ . }}</a></li>
-            {{ end }}
-          </ul>
+        {{ else }}
+        <img src="{{ $profile }}" alt="" class="mr-3 border-4 border-white rounded-full h-11 drop-shadow-lg">
+        {{ end }}
+        
+        {{ range .Params.authors }}
+        <span class="blog-date">
+          <a href="/authors/{{ . | urlize }}" class="single-multi-author">{{ . }}</a> {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp;
+        </span>
+        <span>
+          {{ range .Params.tags }}
+          <a href="/tags/{{ . | urlize }}" class="blog-tag">{{ . }}</a>
+        </span>
+        {{ end }}
+
       </div>
 
       <article class="max-w-[800px] mx-auto prose">
@@ -60,25 +64,26 @@
     </p>
 
     <div class="flex flex-col md:flex-row text-center mx-auto border-t pt-6 mt-6 align-center justify-between gap-10">
-      <div class="lg:w-1/2 text-center">
+      <div class="lg:w-1/2">
         <h2 class="text-lg text-[#1D65A6] font-bold mb-3">
           {{ i18n "writtenBy" }}:</h2>
         <div class="flex items-center">
           {{ $profile := .Params.profile }}
-          {{ if eq (len .Params.authors) 1}}
+        {{ if eq (len .Params.authors) 1}}
+        {{ range .Params.authors }}
+        <a href="/authors/{{ . | urlize }}">
+          <img src="{{ $profile }}" alt="" class="mr-3 border-4 border-white rounded-full h-11 drop-shadow-lg">
+        </a>
+        {{ end }}
+        {{ else }}
+        <img src="{{ $profile }}" alt="" class="mr-3 border-4 border-white rounded-full h-11 drop-shadow-lg">
+        {{ end }}
           {{ range .Params.authors }}
-          <a href="/authors/{{ . | urlize }}" class="flex items-center justify-center">
-          <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full drop-shadow-lg w-14 h-14">
-          <span class="lg:w-[20ch] mx-2">{{ . }}</span>
-          </a>
-          {{ end }}
-          {{ else }}
-          <img src="{{ $profile }}" alt="" class="border-4 border-white rounded-full drop-shadow-lg w-14 h-14">
-          {{ range .Params.authors }}
-          <span class="lg:w-[20ch] mx-2"><a href="/authors/{{ . | urlize }}">{{ . }}</a></span>
-          {{ end }}
-          {{ end }}
-        </div>
+          <span class="flex flex-wrap">
+            <a href="/authors/{{ . | urlize }}" class="single-multi-author lg:w-[20ch] mx-2">{{ . }}</a> 
+            {{ end }}
+          </span>
+      </div>
       </div>
       <div class="lg:w-1/2">
         <h2 class="text-lg text-[#1D65A6] font-bold mb-3">{{ i18n "sharePost" }}:</h2>

--- a/static/output.css
+++ b/static/output.css
@@ -1138,11 +1138,6 @@ video {
   margin-bottom: 1rem;
 }
 
-.mx-2 {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-}
-
 .my-8 {
   margin-top: 2rem;
   margin-bottom: 2rem;
@@ -1176,6 +1171,16 @@ video {
 .mx-20 {
   margin-left: 5rem;
   margin-right: 5rem;
+}
+
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.mx-10 {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
 }
 
 .ml-10 {
@@ -1218,8 +1223,8 @@ video {
   margin-top: 3.5rem;
 }
 
-.ml-3 {
-  margin-left: 0.75rem;
+.mr-3 {
+  margin-right: 0.75rem;
 }
 
 .mb-3 {
@@ -1266,6 +1271,10 @@ video {
   margin-left: 5rem;
 }
 
+.ml-3 {
+  margin-left: 0.75rem;
+}
+
 .mt-5 {
   margin-top: 1.25rem;
 }
@@ -1300,10 +1309,6 @@ video {
 
 .mt-1 {
   margin-top: 0.25rem;
-}
-
-.mr-3 {
-  margin-right: 0.75rem;
 }
 
 .mb-4 {
@@ -1386,10 +1391,6 @@ video {
   height: 2.75rem;
 }
 
-.h-14 {
-  height: 3.5rem;
-}
-
 .h-6 {
   height: 1.5rem;
 }
@@ -1412,6 +1413,10 @@ video {
 
 .h-8 {
   height: 2rem;
+}
+
+.h-14 {
+  height: 3.5rem;
 }
 
 .h-3 {
@@ -1459,10 +1464,6 @@ video {
   width: 4rem;
 }
 
-.w-14 {
-  width: 3.5rem;
-}
-
 .w-6 {
   width: 1.5rem;
 }
@@ -1497,6 +1498,10 @@ video {
 
 .w-\[1080px\] {
   width: 1080px;
+}
+
+.w-\[20ch\] {
+  width: 20ch;
 }
 
 .max-w-7xl {
@@ -2375,11 +2380,6 @@ video {
   color: rgb(29 102 166 / var(--tw-text-opacity));
 }
 
-.text-\[\#E66809\] {
-  --tw-text-opacity: 1;
-  color: rgb(230 104 9 / var(--tw-text-opacity));
-}
-
 .text-\[\#DB3B00\] {
   --tw-text-opacity: 1;
   color: rgb(219 59 0 / var(--tw-text-opacity));
@@ -2855,6 +2855,18 @@ em {
 }
 
 .blog-tag:first-child::before {
+  content: '';
+}
+
+.list-multi-author::after {
+  content: '\00a0&';
+}
+
+.single-multi-author::after {
+  content: '\00a0&\00a0';
+}
+
+.list-multi-author:last-child::after, .single-multi-author:last-child::after {
   content: '';
 }
 
@@ -3367,6 +3379,10 @@ em {
 
   .lg\:w-1\/2 {
     width: 50%;
+  }
+
+  .lg\:w-\[24ch\] {
+    width: 24ch;
   }
 
   .lg\:w-\[20ch\] {


### PR DESCRIPTION
Scope of Changes:

Amends styling of blog posts with multiple authors to wrap the names instead of having the first name listed above the last name.

How blog posts with multiple authors currently appears:
<img width="431" alt="Screenshot 2023-10-09 at 5 49 08 PM" src="https://github.com/rotationalio/rotational.io/assets/94616884/cb5d62ed-849c-4d76-98ba-031e43cd7887">


Fixes SC-21826

Acceptance Criteria:
https://www.awesomescreenshot.com/video/21445789?key=6666060fd895e299109fad2ac43f340a