### PR TITLE
Changes text color for Ensign use cases and features headers

### DIFF
--- a/layouts/partials/services-testimonial.html
+++ b/layouts/partials/services-testimonial.html
@@ -1,11 +1,11 @@
 <div class="mt-12 md:mx-32 lg:mx-40 bg-[#ECF6FF] lg:mt-14 p-6 rounded-xl">
   <p class="text-xl text-center">
-    "<span class="text-[#DB3B00] font-bold">Rotational Labs</span> has been a true partner to us 
+    "<span class="text-[#A32C00] font-bold">Rotational Labs</span> has been a true partner to us 
     -- from helping us realize and deploy our ambitious visions for next-gen supply chain analytics, 
     to empowering our technical team with the skills and ability to maintain our products and services long-term."
   </p>
   <p class="pt-4 text-xl text-center">
-    <span class="text-[#DB3B00] font-bold">Sebastian Sobolev</span>,
+    <span class="text-[#A32C00] font-bold">Sebastian Sobolev</span>,
     <span class="text-[#192E5B] font-bold">BlueVoyant Group</span>
   </p>
 </div>

--- a/layouts/shortcodes/features-header.html
+++ b/layouts/shortcodes/features-header.html
@@ -1,1 +1,1 @@
-<h4 class="mx-4 max-h-fit font-bold text-xl text-left text-[#1D65A6]">{{ .Inner }}</h4>
+<h4 class="mx-4 max-h-fit font-bold text-xl text-left text-[#A32C00]">{{ .Inner }}</h4>

--- a/layouts/shortcodes/usecase-header.html
+++ b/layouts/shortcodes/usecase-header.html
@@ -1,3 +1,3 @@
-<div class="mb-4 text-[#1D65A6]">
+<div class="mb-4 text-[#192E5B]">
     {{ .Inner | markdownify }}
 </div>

--- a/static/output.css
+++ b/static/output.css
@@ -2375,19 +2375,9 @@ video {
   color: rgb(29 102 166 / var(--tw-text-opacity));
 }
 
-.text-\[\#DB3B00\] {
-  --tw-text-opacity: 1;
-  color: rgb(219 59 0 / var(--tw-text-opacity));
-}
-
 .text-\[\#A32C00\] {
   --tw-text-opacity: 1;
   color: rgb(163 44 0 / var(--tw-text-opacity));
-}
-
-.text-\[\#802200\] {
-  --tw-text-opacity: 1;
-  color: rgb(128 34 0 / var(--tw-text-opacity));
 }
 
 .underline {

--- a/static/output.css
+++ b/static/output.css
@@ -2380,6 +2380,16 @@ video {
   color: rgb(219 59 0 / var(--tw-text-opacity));
 }
 
+.text-\[\#A32C00\] {
+  --tw-text-opacity: 1;
+  color: rgb(163 44 0 / var(--tw-text-opacity));
+}
+
+.text-\[\#802200\] {
+  --tw-text-opacity: 1;
+  color: rgb(128 34 0 / var(--tw-text-opacity));
+}
+
 .underline {
   text-decoration-line: underline;
 }


### PR DESCRIPTION
Scope of Changes:

- Changes color for Ensign features and Ensign use cases emphasis text

Fixes SC-21888

Note: The text color applied to the Ensign features, `#A32C00` is darker than `#DB3B00`, which is listed in the RL palette. Although `#DB3B00` has an acceptable color contrast it could bother some users with light sensitivity issues.

In addition to the images below, screenshots of alternative options may be viewed here: https://www.awesomescreenshot.com/s/folder/F09R0EqZ02/9514c8f60b7236ad528196bdd2ab6dda

Acceptance Criteria:

The light blue text in the 2nd image are all links.

![Rotational Labs (4)](https://github.com/rotationalio/rotational.io/assets/94616884/cf5c0655-b581-44ea-90ef-3177cad9970c)

![Rotational Labs _ Ensign Use Cases](https://github.com/rotationalio/rotational.io/assets/94616884/be804316-05a8-4028-9229-7a576f54c8d7)
