### PR TITLE
Adds products section and updates services page copy

### DIFF
--- a/content/en/services/index.md
+++ b/content/en/services/index.md
@@ -1,7 +1,8 @@
 ---
 title: "Services"
 date: 2022-10-05T12:40:26Z
-headertext: "Consulting Services"
+headertext: "Services"
+subheadertext: "Your End-to-End Data Team"
 noicon: true
 type: "services"
 image: "img/horizontal-global-data-flow.png"

--- a/data/en/products.yml
+++ b/data/en/products.yml
@@ -1,0 +1,15 @@
+############################# Products ###################################
+products:
+  enable: true
+  title: Products
+  subtitle: With deep industry and government experience, we can deliver on your most important priorities.
+  products:
+    - product_name: Ensign
+      description: Ensign is a database-meets-event-streaming platform for data science teams that want to get their data moving and their models into production.
+      link: /ensign
+    - product_name: Yellowbrick
+      description: Yellowbrick is an open source project built using Python that extends the scikit-learn API with visual analysis and diagnostic tools. The Yellowbrick library is a diagnostic visualization platform for machine learning.
+      link: https://www.scikit-yb.org/en/latest/index.html
+    - product_name: Baleen
+      description: Baleen is an automated ingestion service of RSS feeds to construct a corpus for NLP research.
+      link: https://github.com/rotationalio/baleen

--- a/data/en/products.yml
+++ b/data/en/products.yml
@@ -2,13 +2,15 @@
 products:
   enable: true
   title: Products
-  subtitle: With deep industry and government experience, we can deliver on your most important priorities.
+  subtitle: We know it can be tricky to turn research code into a user-facing product, and we're happy to share 
+            our product expertise, tricks, and lessons learned with our clients.
   products:
     - product_name: Ensign
       description: Ensign is a database-meets-event-streaming platform for data science teams that want to get their data moving and their models into production.
       link: /ensign
     - product_name: Yellowbrick
-      description: Yellowbrick is an open source project built using Python that extends the scikit-learn API with visual analysis and diagnostic tools. The Yellowbrick library is a diagnostic visualization platform for machine learning.
+      description: Yellowbrick is an open source project built using Python that extends the scikit-learn API with visual analysis and diagnostic tools. 
+                   The Yellowbrick library is a diagnostic visualization platform for machine learning.
       link: https://www.scikit-yb.org/en/latest/index.html
     - product_name: Baleen
       description: Baleen is an automated ingestion service of RSS feeds to construct a corpus for NLP research.

--- a/data/en/services.yml
+++ b/data/en/services.yml
@@ -1,17 +1,14 @@
 ############################# Services ###################################
 services:
   enable : true
-  title : Consulting Services
-  subtitle: |
-    "Rotational Labs has been a true partner to us -- from helping us realize and deploy our ambitious visions for next-gen supply chain analytics, to empowering our technical team with the skills and ability to maintain our products and services long-term." - Sebastian Sobolev, BlueVoyant Group
+  title : Services
   approach:
     enable : true
-    title: Our Value
+    title: What You See Is What You Get
     description: |
-      We work with our clients to leverage **event-driven microservices** to deliver rich,
-      personalized user experiences, real-time business insights, and streamlined machine
-      learning operations. We also help our customers future proof and stay compliant with
-      privacy regulations.
+      We're **a proven team of senior data scientists and engineers** ready to tackle complex data and machine learning projects 
+      in government or commercial markets. We deliver solutions through advisory, software engineering, and data science services. 
+      We scope, sequence, and budget projects for client success.
   services:
     enable : true
   partners:

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -21,7 +21,12 @@
 
     <div class="md:flex md:space-x-5 items-center pl-2 py-5 rounded-lg bg-[#F5F5F5]">
         <p class="pb-6 md:pb-0 font-bold md:text-xl">Schedule your no-cost, risk-free consultation.</p>
-        <a href="/contact" class="border rounded-lg text-white font-bold bg-[#1D65A6] p-2.5">Schedule Consultation</a>
+        {{ $data := index site.Data site.Language.Lang }}
+        {{ if $data.services.services.action.enable }}
+        {{ with $data.services.services.action }}
+        <a href="{{ .schedule_link }}" target="_blank" class="border rounded-lg text-white font-bold bg-[#1D65A6] p-2.5">Schedule Consultation</a>
+        {{ end }}
+        {{ end }}
     </div>
 </section>
 {{ end }}

--- a/layouts/services/single.html
+++ b/layouts/services/single.html
@@ -19,7 +19,7 @@
         
         {{ if $data.wheelhouse.wheelhouse.enable}}
         {{ with $data.wheelhouse.wheelhouse }}
-        <section class="mt-9">
+        <section class="mt-9 lg:my-14">
             <h2 class="mb-4 font-bold text-xl sm:text-2xl lg:text-3xl">{{ .title }}</h2>
             <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 sm:mt-8 text-center">
                 {{ range .experience }}
@@ -87,7 +87,34 @@
                     
         </section>
         {{ end }}
-        {{ end }}  
+        {{ end }}
+        
+        {{ if $data.products.products.enable }}
+        {{ with $data.products.products }}
+        <section class="my-9 lg:my-14">
+            <h2 class="mb-4 font-bold text-xl sm:text-2xl lg:text-3xl">{{ .title }}</h2>
+            <p class="md:text-xl">{{ .subtitle }}</p>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mt-8 text-center">
+                {{ range .products }}
+                <div class="bg-[#1D65A6] pb-4 rounded-md text-[#FCFCFC]">
+                    <div>
+                        <h4 class="text-lg md:text-xl font-bold my-6">{{ .product_name}}</h4>
+                        <p class="md:text-lg mx-4 pb-4 md:pb-0 md:h-64">{{ .description }}</p>
+                    </div>
+                    <a href="{{ .link }}" class="flex justify-center items-center md:text-lg font-bold">
+                        <span class="mr-1">
+                            Learn More 
+                        </span>
+                        <img src="img/arrow-right.png" class="" />
+                        <img src="img/arrow-right.png" class="" />
+                    </a>
+                </div>
+                {{ end }}
+            </div>
+                    
+        </section>
+        {{ end }}
+        {{ end }} 
         
         {{ if .action.enable }}
         {{ with .action }}

--- a/layouts/services/single.html
+++ b/layouts/services/single.html
@@ -72,7 +72,7 @@
                 <div class="bg-[#1D65A6] pb-4 rounded-md text-[#FCFCFC]">
                     <div>
                         <h4 class="text-lg md:text-xl font-bold my-6">{{ .client_name}}</h4>
-                        <p class="md:text-lg mx-4 pb-4 md:pb-0 md:h-64">{{ .summary }}</p>
+                        <p class="md:text-lg mx-4 pb-4 md:pb-0 md:h-72 xl:h-64">{{ .summary }}</p>
                     </div>
                     <a href="{{ .link }}" class="flex justify-center items-center md:text-lg font-bold">
                         <span class="mr-1">
@@ -99,9 +99,9 @@
                 <div class="bg-[#1D65A6] pb-4 rounded-md text-[#FCFCFC]">
                     <div>
                         <h4 class="text-lg md:text-xl font-bold my-6">{{ .product_name}}</h4>
-                        <p class="md:text-lg mx-4 pb-4 md:pb-0 md:h-64">{{ .description }}</p>
+                        <p class="md:text-lg mx-4 pb-4 md:pb-0 md:h-64 xl:h-56">{{ .description }}</p>
                     </div>
-                    <a href="{{ .link }}" class="flex justify-center items-center md:text-lg font-bold">
+                    <a href="{{ .link }}" target="_blank" class="flex justify-center items-center md:text-lg font-bold">
                         <span class="mr-1">
                             Learn More 
                         </span>

--- a/layouts/services/single.html
+++ b/layouts/services/single.html
@@ -78,8 +78,8 @@
                         <span class="mr-1">
                             Learn More 
                         </span>
-                        <img src="img/arrow-right.png" class="" />
-                        <img src="img/arrow-right.png" class="" />
+                        <img src="img/arrow-right.png"/>
+                        <img src="img/arrow-right.png" />
                     </a>
                 </div>
                 {{ end }}
@@ -105,8 +105,8 @@
                         <span class="mr-1">
                             Learn More 
                         </span>
-                        <img src="img/arrow-right.png" class="" />
-                        <img src="img/arrow-right.png" class="" />
+                        <img src="img/arrow-right.png" />
+                        <img src="img/arrow-right.png" />
                     </a>
                 </div>
                 {{ end }}

--- a/static/output.css
+++ b/static/output.css
@@ -1423,8 +1423,8 @@ video {
   height: 3.5rem;
 }
 
-.h-28 {
-  height: 7rem;
+.h-\[92px\] {
+  height: 92px;
 }
 
 .h-20 {
@@ -1437,10 +1437,6 @@ video {
 
 .h-\[100px\] {
   height: 100px;
-}
-
-.h-\[92px\] {
-  height: 92px;
 }
 
 .max-h-\[136px\] {
@@ -1506,10 +1502,6 @@ video {
 
 .w-auto {
   width: auto;
-}
-
-.w-28 {
-  width: 7rem;
 }
 
 .w-\[1080px\] {
@@ -3353,14 +3345,14 @@ em {
     margin-right: 10rem;
   }
 
-  .lg\:my-0 {
-    margin-top: 0px;
-    margin-bottom: 0px;
-  }
-
   .lg\:my-14 {
     margin-top: 3.5rem;
     margin-bottom: 3.5rem;
+  }
+
+  .lg\:my-0 {
+    margin-top: 0px;
+    margin-bottom: 0px;
   }
 
   .lg\:mt-14 {

--- a/static/output.css
+++ b/static/output.css
@@ -3203,6 +3203,14 @@ em {
     height: 280px;
   }
 
+  .md\:h-60 {
+    height: 15rem;
+  }
+
+  .md\:h-72 {
+    height: 18rem;
+  }
+
   .md\:w-1\/2 {
     width: 50%;
   }
@@ -3419,8 +3427,20 @@ em {
     height: 15rem;
   }
 
+  .lg\:h-44 {
+    height: 11rem;
+  }
+
   .lg\:h-\[380px\] {
     height: 380px;
+  }
+
+  .lg\:h-52 {
+    height: 13rem;
+  }
+
+  .lg\:h-56 {
+    height: 14rem;
   }
 
   .lg\:w-1\/2 {
@@ -3512,6 +3532,14 @@ em {
 
   .xl\:grid {
     display: grid;
+  }
+
+  .xl\:h-56 {
+    height: 14rem;
+  }
+
+  .xl\:h-64 {
+    height: 16rem;
   }
 
   .xl\:w-\[96\%\] {


### PR DESCRIPTION
Scope of Changes:

- Updates copy on services page
- Adds `Products` section below the `Case Studies` section
- Updates schedule consultation link on single case studies pages

Note: The `Learn More` doesn't currently navigate users to a single.html page like what's currently done in the `Case Studies` section. If we'd like to go that direction, it will not take long to implement.

Video of Changes:
https://www.awesomescreenshot.com/video/22033619?key=1d280a18471a61c817aa204fbd82f9d4