### PR TITLE
Makes style applied to p elements on ensign u page more specific

### DIFF
--- a/input.css
+++ b/input.css
@@ -375,16 +375,16 @@ em {
   padding-right: .5em;
 }
 
-.ensign-u h3 {
+.ensign-u > h3 {
   margin-top: 12px;
 }
 
-.ensign-u p, li {
+.ensign-u > p, .ensign-u > li {
   font-size: 1.25rem;
   line-height: 2rem;
 }
 
-.ensign-u ol, #pre-reqs + ul {
+.ensign-u > ol, #pre-reqs + ul {
   margin-bottom: 24px;
 }
 
@@ -392,7 +392,7 @@ em {
   margin-bottom: 32px;
 }
 
-.ensign-u li::marker {
+.ensign-u ul > li::marker {
   color: black;
 }
 

--- a/input.css
+++ b/input.css
@@ -379,7 +379,7 @@ em {
   margin-top: 12px;
 }
 
-.ensign-u > p, .ensign-u > li {
+.ensign-u > p, .ensign-u > ul > li, .ensign-u > ol > li {
   font-size: 1.25rem;
   line-height: 2rem;
 }

--- a/static/output.css
+++ b/static/output.css
@@ -2900,16 +2900,16 @@ em {
   padding-right: .5em;
 }
 
-.ensign-u h3 {
+.ensign-u > h3 {
   margin-top: 12px;
 }
 
-.ensign-u p, li {
+.ensign-u > p, .ensign-u > li {
   font-size: 1.25rem;
   line-height: 2rem;
 }
 
-.ensign-u ol, #pre-reqs + ul {
+.ensign-u > ol, #pre-reqs + ul {
   margin-bottom: 24px;
 }
 
@@ -2917,7 +2917,7 @@ em {
   margin-bottom: 32px;
 }
 
-.ensign-u li::marker {
+.ensign-u ul > li::marker {
   color: black;
 }
 

--- a/static/output.css
+++ b/static/output.css
@@ -2904,7 +2904,7 @@ em {
   margin-top: 12px;
 }
 
-.ensign-u > p, .ensign-u > li {
+.ensign-u > p, .ensign-u > ul > li, .ensign-u > ol > li {
   font-size: 1.25rem;
   line-height: 2rem;
 }


### PR DESCRIPTION
Scope of Changes:

This increases the specificity of the style applied to `p` elements on the Ensign U page. The style was also applied to the summary of blog posts on certain pages, so increasing the specificity should remove the style from the summaries.

Fixes SC-22823

Acceptance Criteria:
https://www.awesomescreenshot.com/video/22997349?key=493afd71d04ff87ce7da5c3c6cadad28