### PR TITLE
Adds list and term pages for taxonomies added for resource page

### DIFF
--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+  <div class="mt-9 sm:mt-11 lg:mt-14">
+    <ul class="b-card">
+      {{ range .Site.Taxonomies.categories }}
+      <li class="mx-20 mb-4 py-4 rounded-xl bg-[#1D65A6] text-white text-center font-semibold">
+        <a href="{{ .Page.Permalink }}" class="block">{{ .Page.Title }}</a>
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/layouts/categories/term.html
+++ b/layouts/categories/term.html
@@ -1,0 +1,22 @@
+{{ define "title" }}
+{{ .Title }} &ndash; {{ .Site.Title }}
+{{ end }}
+
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-2">
+    <section class="mt-9 sm:mt-11 lg:mt-14">
+        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
+            {{ $paginator := .Paginate .Data.Pages }}
+            {{ range $paginator.Pages }}
+            <li class="mt-6 sm:mt-0 h-auto">
+               {{ .Render "resource" }}
+            </li>
+            {{ end }}
+
+        </ul>
+
+        {{ partial "paginator.html" . }}
+
+    </section>
+</div>
+{{ end }}

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+  <div class="mt-9 sm:mt-11 lg:mt-14">
+    <ul class="b-card">
+      {{ range .Site.Taxonomies.events }}
+      <li class="mx-20 mb-4 py-4 rounded-xl bg-[#1D65A6] text-white text-center font-semibold">
+        <a href="{{ .Page.Permalink }}" class="block">{{ .Page.Title }}</a>
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/layouts/events/term.html
+++ b/layouts/events/term.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+    <div class="mt-9 sm:mt-11 lg:mt-14">
+        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
+            {{ $paginator := .Paginate .Data.Pages }}
+            {{ range $paginator.Pages }}
+            <li class="mt-6 sm:mt-0 h-auto">
+                {{ .Render "resource" }}
+            </li>
+            {{ end }}
+
+        </ul>
+
+
+        {{ partial "paginator.html" . }}
+
+    </div>
+</div>
+{{ end }}

--- a/layouts/presenters/list.html
+++ b/layouts/presenters/list.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+  <div class="mt-9 sm:mt-11 lg:mt-14">
+    <ul class="b-card">
+      {{ range .Site.Taxonomies.presenters }}
+      <li class="mx-20 mb-4 py-4 rounded-xl bg-[#1D65A6] text-white text-center font-semibold">
+        <a href="{{ .Page.Permalink }}" class="block">{{ .Page.Title }}</a>
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/layouts/presenters/term.html
+++ b/layouts/presenters/term.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+    <div class="mt-9 sm:mt-11 lg:mt-14">
+        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
+            {{ $paginator := .Paginate .Data.Pages }}
+            {{ range $paginator.Pages }}
+            <li class="mt-6 sm:mt-0 h-auto">
+                {{ .Render "resource" }}
+            </li>
+            {{ end }}
+
+        </ul>
+
+
+        {{ partial "paginator.html" . }}
+
+    </div>
+</div>
+{{ end }}

--- a/layouts/topics/list.html
+++ b/layouts/topics/list.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+  <div class="mt-9 sm:mt-11 lg:mt-14">
+    <ul class="b-card">
+      {{ range .Site.Taxonomies.topics }}
+      <li class="mx-20 mb-4 py-4 rounded-xl bg-[#1D65A6] text-white text-center font-semibold">
+        <a href="{{ .Page.Permalink }}" class="block">{{ .Page.Title }}</a>
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+</div>
+{{ end }}

--- a/layouts/topics/term.html
+++ b/layouts/topics/term.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+    <div class="mt-9 sm:mt-11 lg:mt-14">
+        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
+            {{ $paginator := .Paginate .Data.Pages }}
+            {{ range $paginator.Pages }}
+            <li class="mt-6 sm:mt-0 h-auto">
+                {{ .Render "resource" }}
+            </li>
+            {{ end }}
+
+        </ul>
+
+
+        {{ partial "paginator.html" . }}
+
+    </div>
+</div>
+{{ end }}


### PR DESCRIPTION
Scope of Changes:

Adds list and term pages for the following taxonomies added while creating the resources page:
- Categories
- Events
- Presenters
- Topics 

Note: To keep the `resources` and `blog posts` separate, the `presenters` and `topics` taxonomies were created instead of using 'authors' and 'tags'. 

The change will allow users to see all resources with a specific taxonomy term applied to it. This is like how users are able to click on a blog post tag and view other posts with the same tag.

Acceptance Criteria: https://www.awesomescreenshot.com/video/23103579?key=843e3b4c8eb287757fb9c13ccbb3b291

Note: Test resources were created for the video above, but were not committed. If this branch is viewed locally, the test resources will not appear. 

To create a test resource run the following command:
```
$ hugo new resources/your-resource-name.md
```

In a separate story, the list page will be updated to make the resources have the same height.