### PR TITLE
Gives list items on term pages bg color

### DIFF
--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -11,10 +11,10 @@
                     </li> 
                 {{ end }}
             </ul>
-            <h3 class="text-xl font-extrabold mt-3 pb-2 "><a class="block h-24" href="{{ .Permalink }}">{{ .Title }}</a>
+            <h3 class="text-xl font-extrabold mt-3 pb-2 "><a class="block h-auto md:h-24" href="{{ .Permalink }}">{{ .Title }}</a>
             </h3>
-            <div class='h-36'>
-                <p class="mt-8 text-base">{{ .Summary | markdownify | truncate 240 }}</p>
+            <div class='h-auto md:h-36'>
+                <p class="mt-3 md:mt-8 text-base">{{ .Summary | markdownify | truncate 240 }}</p>
 
             </div>
 

--- a/layouts/categories/term.html
+++ b/layouts/categories/term.html
@@ -8,7 +8,7 @@
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
-            <li class="mt-6 sm:mt-0 h-auto">
+            <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                {{ .Render "resource" }}
             </li>
             {{ end }}

--- a/layouts/events/term.html
+++ b/layouts/events/term.html
@@ -4,7 +4,7 @@
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
-            <li class="mt-6 sm:mt-0 h-auto">
+            <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "resource" }}
             </li>
             {{ end }}

--- a/layouts/presenters/term.html
+++ b/layouts/presenters/term.html
@@ -4,7 +4,7 @@
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
-            <li class="mt-6 sm:mt-0 h-auto">
+            <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "resource" }}
             </li>
             {{ end }}

--- a/layouts/tags/term.html
+++ b/layouts/tags/term.html
@@ -4,7 +4,7 @@
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
-            <li class="mt-6 sm:mt-0 h-auto">
+            <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "article" }}
             </li>
             {{ end }}

--- a/layouts/topics/term.html
+++ b/layouts/topics/term.html
@@ -4,7 +4,7 @@
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
-            <li class="mt-6 sm:mt-0 h-auto">
+            <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "resource" }}
             </li>
             {{ end }}

--- a/static/output.css
+++ b/static/output.css
@@ -2395,6 +2395,10 @@ video {
   padding-top: 0.25rem;
 }
 
+.pt-2 {
+  padding-top: 0.5rem;
+}
+
 .text-left {
   text-align: left;
 }
@@ -3963,12 +3967,20 @@ em {
     margin-left: 1.25rem;
   }
 
+  .xl\:mt-auto {
+    margin-top: auto;
+  }
+
   .xl\:grid {
     display: grid;
   }
 
   .xl\:h-56 {
     height: 14rem;
+  }
+
+  .xl\:h-auto {
+    height: auto;
   }
 
   .xl\:w-\[96\%\] {


### PR DESCRIPTION
Scope of Changes:

Adds bg color to `<li>` on terms pages to prevent them for appearing as if they don't have the same height.

Sets height on blog post title to `auto` on smaller screens to remove space between the title and intro.

Fixes SC-22964

Acceptance Criteria:
https://www.awesomescreenshot.com/video/23518407?key=932c61f64b2b889e1447c552821f97d2