### PR TITLE
Add photo credit to single blog layout

### DIFF
--- a/content/en/blog/2022-07-08-transparently-mocking-grpc-services.md
+++ b/content/en/blog/2022-07-08-transparently-mocking-grpc-services.md
@@ -6,7 +6,7 @@ draft: false
 authors: [Patrick Deziel]
 image: img/blog/blue_laser.jpg
 tags: ['gRPC', 'Mocks', 'Programming']
-photo_credit: JJ Ying via Unsplash
+photo_credit: Photo by JJ Ying via Unsplash
 description: "gRPC is a common framework used to facilitate communication between microservices, but testing these services can be a challenge. In this post we will present a simple strategy for mocking gRPC services in Go."
 profile: img/team/patrick-deziel.png
 ---

--- a/content/en/blog/2022-09-21-eventing-benchmarks.md
+++ b/content/en/blog/2022-09-21-eventing-benchmarks.md
@@ -6,7 +6,7 @@ draft: true
 authors: [Rebecca Bilbro]
 image: img/blog/pastries.jpg
 tags: ['Microservices', 'Eventing', 'Programming']
-photo_credit: George Tan via Flickr Commons
+photo_credit: Photo by George Tan via Flickr Commons
 description: "In this post we'll dig into the wild world of eventing system performance benchmarks, and explore how features like throughput and latency compare for different eventing platforms."
 profile: img/team/rebecca-bilbro.png
 ---

--- a/content/en/blog/2023-04-01-ensign-for-enterprise-ai.md
+++ b/content/en/blog/2023-04-01-ensign-for-enterprise-ai.md
@@ -7,7 +7,7 @@ image: img/blog/bridgerace.jpg
 authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ['AI', 'Automation']
-photo_credit: Metropolitan Transportation Authority via Flickr Commons
+photo_credit: Photo by Metropolitan Transportation Authority via Flickr Commons
 description: "Everyone is gearing up to win the AI/automation race. Who will win?"
 ---
 

--- a/content/en/blog/2023-05-05-esg-is-a-data-problem.md
+++ b/content/en/blog/2023-05-05-esg-is-a-data-problem.md
@@ -7,7 +7,7 @@ image: img/blog/light-through-trees.jpg
 authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ['ESG', 'Ensign', 'Eventing']
-photo_credit: Christian Buehner via Unsplash
+photo_credit: Photo by Christian Buehner via Unsplash
 description: "ESG mandates will impose data synthesis challenges on publicly traded companies. Ensign -- a secure data collaboration platform -- is poised to help."
 ---
 

--- a/content/en/blog/2023-09-27-uchicago-hackathon.md
+++ b/content/en/blog/2023-09-27-uchicago-hackathon.md
@@ -4,7 +4,7 @@ slug: "uchicago-hackathon"
 date: "2023-09-27T08:04:58-07:00"
 draft: false
 image: img/blog/autumn_leaves.jpg
-photo_credit: "Hiro via Flickr Commons"
+photo_credit: "Photo by Hiro via Flickr Commons"
 authors: ["Edwin Schmierer"]
 profile: img/team/edwin-schmierer.png
 tags: ["Hackathon", "Data Science", "Python"]

--- a/content/en/blog/2023-12-08-pubsub-101---querying-topics.md
+++ b/content/en/blog/2023-12-08-pubsub-101---querying-topics.md
@@ -4,7 +4,7 @@ slug: "pubsub-101---querying-topics"
 date: "2023-12-08T14:09:46-06:00"
 draft: false
 image: img/blog/otter_investigator.png
-photo_credit: "Pangstu"
+photo_credit: "Photo by Pangstu"
 authors: ['Patrick Deziel']
 profile: img/team/patrick-deziel.png
 tags: ['Ensign', 'enSQL', 'PubSub 101']

--- a/content/en/blog/2024-01-09-real-time-flight-delays.md
+++ b/content/en/blog/2024-01-09-real-time-flight-delays.md
@@ -4,7 +4,7 @@ slug: "real-time-flight-delays"
 date: "2024-01-09T14:58:48-05:00"
 draft: false
 image: /img/blog/2024-01-09-real-time-flight-delays/nasa-virtual-airport.jpg
-photo_credit: "NASA Commons CD99-0095-1.1"
+photo_credit: "Photo by NASA Commons CD99-0095-1.1"
 authors: ['Jason Chandra', 'Kevin Sianto', 'Toby Chiu']
 profile: img/butterfly.png
 tags: ["Hackathon", "Data Science", "Ensign"]

--- a/content/en/blog/2024-01-10-Defend-Your-Moat:-Practical-AI-Strategies-for-2024.md
+++ b/content/en/blog/2024-01-10-Defend-Your-Moat:-Practical-AI-Strategies-for-2024.md
@@ -1,10 +1,10 @@
 ---
 title: "Practical AI Strategies for 2024"
-slug: "Practical-AI-Strategies-for-2024"
+slug: "practical-ai-strategies-for-2024"
 date: "2024-01-10T12:52:57-05:00"
 draft: true
 image: img/blog/2024-01-12-practical-ai-strategies-for-2024/shipping.jpg
-photo_credit: "Photo by <a href="https://unsplash.com/@ihs_photo?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Ian Simmonds</a> on <a href="https://unsplash.com/photos/ship-cruising-on-body-of-water-XrDbdmqsPdk?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>"
+photo_credit: "Photo by [Ian Simmonds on Unsplash](https://unsplash.com/@ihs_photo?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash)"
 authors: ['Edwin Schmerer']
 profile: img/team/edwin-schmierer.png
 tags: ['AI/ML', 'Strategy']

--- a/content/en/resources/defend-your-moat.md
+++ b/content/en/resources/defend-your-moat.md
@@ -1,6 +1,6 @@
 ---
-title: "Defend Your Moat: 4 Practical AI Strategies for 2024"
-slug: "four-practical-ai-strategies-for-2024"
+title: "Defend Your Moat"
+slug: "defend-your-moat"
 draft: false
 event_date: "2023-12-12"
 image: "img/resources/defend-your-moat-webinar.webp"
@@ -9,7 +9,7 @@ description: "How should business and tech leaders approach 2024? We've talked t
 events: ['Webinar']
 registration_link: "https://us06web.zoom.us/webinar/register/6017013025890/WN_DMqpJPulQY-_0-RpVJklGg#/registration"
 call_to_action: Register Now
-video_link: https://www.youtube.com/embed/phdASG6yAsM?si=O8Y6XQ8COJUqT-0i
+video_link:
 audio_link:
 categories: ['Video']
 presenters: ['Edwin Schmierer', 'Benjamin Bengfort']

--- a/content/en/resources/defend-your-moat.md
+++ b/content/en/resources/defend-your-moat.md
@@ -1,6 +1,6 @@
 ---
-title: "Defend Your Moat"
-slug: "defend-your-moat"
+title: "Defend Your Moat: 4 Practical AI Strategies for 2024"
+slug: "four-practical-ai-strategies-for-2024"
 draft: false
 event_date: "2023-12-12"
 image: "img/resources/defend-your-moat-webinar.webp"
@@ -9,7 +9,7 @@ description: "How should business and tech leaders approach 2024? We've talked t
 events: ['Webinar']
 registration_link: "https://us06web.zoom.us/webinar/register/6017013025890/WN_DMqpJPulQY-_0-RpVJklGg#/registration"
 call_to_action: Register Now
-video_link: 
+video_link: https://www.youtube.com/embed/phdASG6yAsM?si=O8Y6XQ8COJUqT-0i
 audio_link:
 categories: ['Video']
 presenters: ['Edwin Schmierer', 'Benjamin Bengfort']

--- a/content/en/resources/defend-your-moat.md
+++ b/content/en/resources/defend-your-moat.md
@@ -9,7 +9,7 @@ description: "How should business and tech leaders approach 2024? We've talked t
 events: ['Webinar']
 registration_link: "https://us06web.zoom.us/webinar/register/6017013025890/WN_DMqpJPulQY-_0-RpVJklGg#/registration"
 call_to_action: Register Now
-video_link:
+video_link: 
 audio_link:
 categories: ['Video']
 presenters: ['Edwin Schmierer', 'Benjamin Bengfort']

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -50,6 +50,9 @@
 
       <article class="max-w-[800px] mx-auto prose">
         {{ .Content | safeHTML }}
+        {{ if .Params.photo_credit }}
+        <span>{{ .Params.photo_credit | markdownify }}</span>
+        {{ end }}
       </article>
     </div>
   </div>


### PR DESCRIPTION
Scope of Changes:

Displays the photo credit on the blog page and adds `Photo by` before credit in some blog posts.

Fixes SC-23325

Acceptance Criteria:
https://www.awesomescreenshot.com/image/45398805?key=ce7529a03cf90cf7a8e75ac665c12dae