### PR TITLE
Sort resources by date on terms pages

### DIFF
--- a/layouts/categories/term.html
+++ b/layouts/categories/term.html
@@ -7,7 +7,7 @@
     <section class="mt-9 sm:mt-11 lg:mt-14">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
-            {{ range $paginator.Pages }}
+            {{ range (.Data.Pages.ByParam "event_date").Reverse }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                {{ .Render "resource" }}
             </li>

--- a/layouts/categories/term.html
+++ b/layouts/categories/term.html
@@ -6,8 +6,8 @@
 <div class="relative max-w-7xl mx-auto px-4 sm:px-2">
     <section class="mt-9 sm:mt-11 lg:mt-14">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
-            {{ $paginator := .Paginate .Data.Pages }}
-            {{ range (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ $pages := (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ range (.Paginate $pages ).Pages }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                {{ .Render "resource" }}
             </li>

--- a/layouts/events/term.html
+++ b/layouts/events/term.html
@@ -2,8 +2,8 @@
 <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
     <div class="mt-9 sm:mt-11 lg:mt-14">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
-            {{ $paginator := .Paginate .Data.Pages }}
-            {{ range (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ $pages := (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ range (.Paginate $pages ).Pages }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "resource" }}
             </li>

--- a/layouts/events/term.html
+++ b/layouts/events/term.html
@@ -3,7 +3,7 @@
     <div class="mt-9 sm:mt-11 lg:mt-14">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
-            {{ range $paginator.Pages }}
+            {{ range (.Data.Pages.ByParam "event_date").Reverse }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "resource" }}
             </li>

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -6,13 +6,16 @@
 <div class="relative max-w-7xl mx-auto px-4 sm:px-2">
     <section class="mt-9 sm:mt-11 lg:mt-14">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
-            {{ range (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ $pages := (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ range (.Paginate $pages ).Pages }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                {{ .Render "resource" }}
             </li>
             {{ end }}
 
         </ul>
+
+        {{ partial "paginator.html" . }}
 
     </section>
 </div>

--- a/layouts/topics/term.html
+++ b/layouts/topics/term.html
@@ -2,8 +2,8 @@
 <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
     <div class="mt-9 sm:mt-11 lg:mt-14">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
-            {{ $paginator := .Paginate .Data.Pages }}
-            {{ range (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ $pages := (.Data.Pages.ByParam "event_date").Reverse }}
+            {{ range (.Paginate $pages ).Pages }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "resource" }}
             </li>

--- a/layouts/topics/term.html
+++ b/layouts/topics/term.html
@@ -3,7 +3,7 @@
     <div class="mt-9 sm:mt-11 lg:mt-14">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
-            {{ range $paginator.Pages }}
+            {{ range (.Data.Pages.ByParam "event_date").Reverse }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl">
                 {{ .Render "resource" }}
             </li>


### PR DESCRIPTION
Scope of Changes:

Resources are sorted by date, from newest to oldest, on the terms pages. Pagination has also been updated to ensure 9 resources are displayed on each page.

Fixes SC-23200

Acceptance Criteria:
https://www.awesomescreenshot.com/video/24495739?key=509f7ddd003b520ae0bf8d9eb4b92b29