### PR TITLE
Add production section border, update Ensign page, make schedule consultation consistent

### DIFF
--- a/content/en/ensign/index.md
+++ b/content/en/ensign/index.md
@@ -79,12 +79,12 @@ How does Ensign stack up to other, similar tools and products?
 <!-- Edit the competitive landscape table at data/en/ensign.yml -->
 {{< competitive-landscape >}}
 
-## Built for the Modern Data Team
+<!-- ## Built for the Modern Data Team
 
-Whether you wear one hat or all the hats, the right tool can make a world of difference.
+Whether you wear one hat or all the hats, the right tool can make a world of difference. -->
 
 <!-- Different Hats Section with 3 Cards -->
-{{< triple >}}
+<!-- {{< triple >}}
 {{% vtriple color="#E3E3E1" %}}
 ### Developers
 
@@ -143,7 +143,7 @@ Let downstream consumers define their own data schemas rather than struggling to
 {{% /skinnyright %}}
 
 {{< comic >}}
-{{% /uneven %}}
+{{% /uneven %}} -->
 
 {{< ensigncoa btnhref="https://rotational.app/register" btntext="Create Account" >}}
 Create your no-cost starter account today!

--- a/data/en/products.yml
+++ b/data/en/products.yml
@@ -20,7 +20,7 @@ products:
       buttons:
         - text: Learn More
           link: /ensign
-        - text: Try Ensign
+        - text: Try Ensign Free
           link: https://rotational.app
         - text: View Pricing
           link: /ensign-pricing

--- a/data/en/products.yml
+++ b/data/en/products.yml
@@ -18,6 +18,8 @@ products:
         - text: No complex cloud vendor accounts or configurations required (or surprise bills)
         - text: Hosted or self-hosted versions available
       buttons:
+        - text: Learn More
+          link: /ensign
         - text: Try Ensign
           link: https://rotational.app
         - text: View Pricing

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -35,12 +35,14 @@
         </section>
     </div>
 
-    <section class="md:flex md:space-x-5 items-center pl-2 py-5 rounded-lg bg-[#F5F5F5]">
+    <section class="md:flex md:justify-between items-center pl-4 py-6 rounded-lg bg-[#E3E3E1]">
         <p class="pb-6 md:pb-0 font-bold md:text-xl">Schedule your no-cost, risk-free consultation.</p>
         {{ $data := index site.Data site.Language.Lang }}
         {{ if $data.services.services.action.enable }}
         {{ with $data.services.services.action }}
-        <a href="{{ .schedule_link }}" target="_blank" class="border rounded-lg text-white font-bold bg-[#1D65A6] p-2.5">Schedule Consultation</a>
+        <div>
+            <a href="{{ .schedule_link }}" target="_blank" class="text-white font-bold bg-[#192E5B] hover:bg-[#1D65A6] p-4 mx-2 rounded-lg">Schedule Consultation</a>
+        </div>
         {{ end }}
         {{ end }}
     </section>

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -15,21 +15,21 @@
   <section class="my-12">
     <h2 class="mb-4 font-bold text-3xl">{{ .product_name }}</h2>
     <p class="mb-4 text-lg">{{ .description }}</p>
-    <section class="grid gap-8 mt-8 lg:mt-14 lg:grid-cols-3">
-      <section>
+    <section class="grid gap-8 mt-8 border-2 rounded lg:grid-cols-3">
+      <section class="mt-6 lg:my-6">
         {{ if eq .product_name "Ensign" }}
         <p class="font-bold text-4xl text-center text-[#1D65A6] mb-4">Ensign</p>
         {{ end }}
         <img src="{{ .logo }}" class="h-48 lg:w-8/12 lg:h-auto mx-auto"/>
       </section>
-      <section class="leading-relaxed lg:w-full">
-        <ul class="ml-4 lg:ml-0">
+      <section class="lg:my-6 leading-relaxed lg:w-full">
+        <ul class="ml-6 lg:ml-0">
           {{ range .product_details }}
-          <li class="list-disc leading-relaxed pb-2">{{ .text }}</li>
+          <li class="list-disc leading-relaxed">{{ .text }}</li>
           {{ end }}
         </ul>
       </section>
-      <section>
+      <section class="lg:my-6">
         <ul>
           {{ range .buttons }}
           <li class="text-center mb-6">

--- a/static/output.css
+++ b/static/output.css
@@ -3761,6 +3761,11 @@ em {
     margin-bottom: 3.5rem;
   }
 
+  .lg\:my-6 {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
   .lg\:ml-0 {
     margin-left: 0px;
   }


### PR DESCRIPTION
Scope of Changes:

- Adds a border around products on the product page. Following this change, margins were also updated.
- Displays a `Learn More` link in the `Ensign` section of the `Products` page that navigates users to the `Ensign` page.
- Hides content on the `Ensign` page. (Additional refactoring may be required in the future.)
- Makes `Schedule Consultation` section and link consistent with similar components on the site.

Fixes SC-23769, SC-23770, SC-23771, & SC-23774

Acceptance Criteria:
https://www.awesomescreenshot.com/video/24779818?key=efd99aa26303703584fdf46db0827dfd