### PR TITLE
Remove additional space between blog tags and author names

### DIFF
--- a/input.css
+++ b/input.css
@@ -401,18 +401,6 @@ em {
   color: black;
 }
 
-.list-multi-author::after {
-  content: '\00a0&';
-}
-
-.single-multi-author::after {
-  content: '\00a0&\00a0';
-}
-
-.list-multi-author:last-child::after, .single-multi-author:last-child::after {
-  content: '';
-}
-
 /* Resource page styles */
 
 #clouds-header, .resource-header {

--- a/input.css
+++ b/input.css
@@ -401,14 +401,6 @@ em {
   color: black;
 }
 
-.blog-tag::before {
-  content: ', ';
-}
-
-.blog-tag:first-child::before {
-  content: '';
-}
-
 .list-multi-author::after {
   content: '\00a0&';
 }

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -6,7 +6,7 @@
         <div class="px-6 pt-4">
             <ul class="flex flex-wrap">
                 {{ range $key, $value := .Params.tags }}
-                    <li class="blog-tag text-base font-bold text-[#1D65A6]">
+                    <li class="text-base font-bold text-[#1D65A6]">
                         <a href="/tags/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }},&nbsp; {{ else }}{{ end }}
                     </li> 
                 {{ end }}
@@ -34,8 +34,8 @@
                 <img src="{{ .Params.profile }}" alt="" class="rounded-full h-10 w-10">
                 <ul class="flex flex-wrap ml-4">
                     {{ range $key, $value := .Params.authors }}
-                    <li class="list-multi-author font-extralight">
-                        <a href="/authors/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.authors) 1) }}, {{ else }}{{ end }}
+                    <li class="font-extralight">
+                        <a href="/authors/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.authors) 1) }},&nbsp; {{ else }}{{ end }}
                     </li>
                     {{ end }}
                 </ul>

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -33,8 +33,10 @@
                 {{ else }}
                 <img src="{{ .Params.profile }}" alt="" class="rounded-full h-10 w-10">
                 <ul class="flex flex-wrap ml-4">
-                    {{ range .Params.authors }}
-                    <li class="list-multi-author font-extralight"><a href="/authors/{{ . | urlize }}">{{ . }}</a></li>
+                    {{ range $key, $value := .Params.authors }}
+                    <li class="list-multi-author font-extralight">
+                        <a href="/authors/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.authors) 1) }}, {{ else }}{{ end }}
+                    </li>
                     {{ end }}
                 </ul>
                 {{ end }}

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -11,16 +11,16 @@
                     </li> 
                 {{ end }}
             </ul>
-            <h3 class="text-xl font-extrabold mt-3 pb-2 "><a class="block h-auto md:h-24" href="{{ .Permalink }}">{{ .Title }}</a>
+            <h3 class="text-xl font-extrabold mt-3 md:mt-4 pb-2 "><a class="block h-auto lg:h-24" href="{{ .Permalink }}">{{ .Title }}</a>
             </h3>
-            <div class='h-auto md:h-36'>
-                <p class="mt-3 md:mt-8 text-base">{{ .Summary | markdownify | truncate 240 }}</p>
+            <div class='h-auto lg:h-36'>
+                <p class="mt-3 md:mt-4 text-base">{{ .Summary | markdownify | truncate 240 }}</p>
 
             </div>
 
         </div>
 
-        <div class="flex justify-between items-center px-6 py-3 border-t mt-6">
+        <div class="flex justify-between items-center px-6 py-3 border-t mt-6 xl:mt-8">
             <div class="flex items-center">
                 {{ $profile := .Params.profile }}
                 {{ if eq (len .Params.authors) 1}}

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -4,10 +4,10 @@
     <div class="bg-[#ECF6FF] rounded-b-xl ">
 
         <div class="px-6 pt-4">
-            <ul class="flex whitespace-nowrap">
-                {{ range .Params.tags }}
+            <ul class="flex flex-wrap">
+                {{ range $key, $value := .Params.tags }}
                     <li class="blog-tag text-base font-bold text-[#1D65A6]">
-                        <a href="/tags/{{ . | urlize }}">{{ . }}</a>
+                        <a href="/tags/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }},&nbsp; {{ else }}{{ end }}
                     </li> 
                 {{ end }}
             </ul>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -3,9 +3,9 @@
 {{ end }}
 
 {{ define "main" }}
-<div class="relative max-w-7xl mx-auto px-4 sm:px-2">
+<div class="relative max-w-7xl mx-auto px-4 sm:px-2 md:px-10 lg:px-2">
     <div class="mt-9 sm:mt-11 lg:mt-14">
-        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
+        <ul class="grid lg:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages }}
             {{ range $paginator.Pages }}
             <li class="mt-6 sm:mt-0 h-auto bg-[#ECF6FF] rounded-b-xl ">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -41,8 +41,8 @@
           <a href="/authors/{{ . | urlize }}" class="single-multi-author">{{ . }}</a> {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp;
         </span>
         <span>
-          {{ range .Params.tags }}
-          <a href="/tags/{{ . | urlize }}" class="blog-tag">{{ . }}</a>
+          {{ range $key, $value := .Params.tags }}
+          <a href="/tags/{{ $value | urlize }}" class="blog-tag">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }},&nbsp; {{ else }}{{ end }}
         </span>
         {{ end }}
 

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -36,13 +36,13 @@
         <img src="{{ $profile }}" alt="" class="mr-3 border-4 border-white rounded-full h-11 drop-shadow-lg">
         {{ end }}
         
-        {{ range .Params.authors }}
-        <span class="blog-date">
-          <a href="/authors/{{ . | urlize }}" class="single-multi-author">{{ . }}</a> {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp;
+        {{ range $key, $value := .Params.authors }}
+        <span>
+          <a href="/authors/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.authors) 1) }}, {{ else }}{{ end }} {{ end }} | {{ dateFormat "Monday, Jan 2, 2006" .Date }} |&nbsp;
         </span>
         <span>
           {{ range $key, $value := .Params.tags }}
-          <a href="/tags/{{ $value | urlize }}" class="blog-tag">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }},&nbsp; {{ else }}{{ end }}
+          <a href="/tags/{{ $value | urlize }}" class="blog-tag">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }}, {{ else }}{{ end }}
         </span>
         {{ end }}
 

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -42,7 +42,7 @@
         </span>
         <span>
           {{ range $key, $value := .Params.tags }}
-          <a href="/tags/{{ $value | urlize }}" class="blog-tag">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }}, {{ else }}{{ end }}
+          <a href="/tags/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }},&nbsp; {{ else }}{{ end }}
         </span>
         {{ end }}
 
@@ -83,7 +83,7 @@
         {{ end }}
           {{ range .Params.authors }}
           <span class="flex flex-wrap">
-            <a href="/authors/{{ . | urlize }}" class="single-multi-author lg:w-[20ch] mx-2">{{ . }}</a> 
+            <a href="/authors/{{ . | urlize }}" class="lg:w-[20ch] mx-2">{{ . }}</a> 
             {{ end }}
           </span>
       </div>
@@ -120,7 +120,7 @@
       </div>
     </div>
     <div>
-      <div class="grid md:grid-cols-2 xl:grid-cols-3 gap-8 sm:mt-16">
+      <div class="grid lg:grid-cols-2 xl:grid-cols-3 gap-8 sm:mt-16">
         {{ range first 3 (where site.RegularPages "Section" "==" "blog")}}
         <div class="mt-6 ">
           {{ .Render "article"}}

--- a/layouts/partials/recent-rotations.html
+++ b/layouts/partials/recent-rotations.html
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div>
-        <div class="grid md:grid-cols-2 xl:grid-cols-3 gap-8 sm:mt-16">
+        <div class="grid lg:grid-cols-2 xl:grid-cols-3 gap-8 sm:mt-16">
             {{ range first 3 (where site.RegularPages "Section" "==" "blog")}}
             <div class="mt-6 ">
                 {{ .Render "article"}}

--- a/static/output.css
+++ b/static/output.css
@@ -3120,18 +3120,6 @@ em {
   color: black;
 }
 
-.list-multi-author::after {
-  content: '\00a0&';
-}
-
-.single-multi-author::after {
-  content: '\00a0&\00a0';
-}
-
-.list-multi-author:last-child::after, .single-multi-author:last-child::after {
-  content: '';
-}
-
 /* Resource page styles */
 
 #clouds-header, .resource-header {

--- a/static/output.css
+++ b/static/output.css
@@ -1434,6 +1434,10 @@ video {
   margin-top: auto;
 }
 
+.mb-auto {
+  margin-bottom: auto;
+}
+
 .block {
   display: block;
 }

--- a/static/output.css
+++ b/static/output.css
@@ -1845,10 +1845,6 @@ video {
   white-space: nowrap;
 }
 
-.whitespace-nowrap {
-  white-space: nowrap;
-}
-
 .rounded {
   border-radius: 0.25rem;
 }
@@ -3122,14 +3118,6 @@ em {
 
 .ensign-u ul > li::marker {
   color: black;
-}
-
-.blog-tag::before {
-  content: ', ';
-}
-
-.blog-tag:first-child::before {
-  content: '';
 }
 
 .list-multi-author::after {

--- a/static/output.css
+++ b/static/output.css
@@ -1434,10 +1434,6 @@ video {
   margin-top: auto;
 }
 
-.mb-auto {
-  margin-bottom: auto;
-}
-
 .block {
   display: block;
 }
@@ -3629,6 +3625,11 @@ em {
     padding: 1.25rem;
   }
 
+  .md\:px-10 {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
   .md\:px-12 {
     padding-left: 3rem;
     padding-right: 3rem;
@@ -3763,6 +3764,14 @@ em {
     height: 3rem;
   }
 
+  .lg\:h-24 {
+    height: 6rem;
+  }
+
+  .lg\:h-36 {
+    height: 9rem;
+  }
+
   .lg\:h-\[380px\] {
     height: 380px;
   }
@@ -3824,6 +3833,11 @@ em {
     padding-right: 3rem;
   }
 
+  .lg\:px-2 {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+
   .lg\:py-5 {
     padding-top: 1.25rem;
     padding-bottom: 1.25rem;
@@ -3868,6 +3882,10 @@ em {
 @media (min-width: 1280px) {
   .xl\:ml-5 {
     margin-left: 1.25rem;
+  }
+
+  .xl\:mt-8 {
+    margin-top: 2rem;
   }
 
   .xl\:grid {


### PR DESCRIPTION
Scope of Changes:

- Fixes issue where additional space appeared between blog post tags and commas (Ex. Data , AI , ML instead of Data, AI, ML)
- Applies fix to blog posts listing multiple authors to ensure additional spaces will not appear between names
- Wraps blog post tags and author names that will not fit on 1 line
- Updates blog grid breakpoints to resolve height issue introduced by wrapping tags

Fixes SC-24045

Acceptance Criteria:
https://www.awesomescreenshot.com/video/25439085?key=427d3f0aa8d14e1a1d1eb3327c0c1941