### PR TITLE
Add YouTube link and description to vector db resource

### DIFF
--- a/content/en/resources/nuts-and-bolts-of-vector-databases.md
+++ b/content/en/resources/nuts-and-bolts-of-vector-databases.md
@@ -5,11 +5,22 @@ draft: false
 event_date: "2024-02-27T12:00:00-05:00"
 image: "img/resources/webinars/nuts-and-bolts-of-vector-databases.webp"
 name: "The Nuts & Bolts of Vector Databases: A No-frills Technical Review"
-description: "Video Coming Soon!"
+description: | 
+  Whether you're working on semantic search, chatbots, sentiment analysis, or other NLP uses cases, understanding the nuts and bolts of vector databases will help you advance your data strategy.
+
+  Dr. Bengfort will dive into the technical intricacies of vector databases, emphasizing their role in managing and querying high-dimensional data, a common scenario in NLP applications. Expect a blend of insights and practical pointers, empowering you to make informed decisions about incorporating vector databases into your NLP projects. 
+
+  **Watch this webinar to:**
+  - Get a clear, practical understanding of vector databases and their role in NLP
+  - Gain insights into the advantages of vector databases over traditional ones in NLP contexts
+  - Discover how to assess vector databases for your NLP applications, focusing on scalability, performance, and compatibility.
+  - Uncover effective strategies for integrating vector databases into your projects
+  - Learn about the latest innovations and trends in vector database technology
+
 events: ['Webinar']
 registration_link: https://us06web.zoom.us/webinar/register/8617062216459/WN_95O7q4B2Si2tivwC9OAmnQ#/registration
 call_to_action: "Register Now"
-video_link: 
+video_link: https://www.youtube.com/embed/BcF0Rh77s7w?si=g5IM8qlnSbvhZUTs
 audio_link: 
 categories: ['Video']
 presenters: ['Benjamin Bengfort']

--- a/content/en/resources/real-technologists-podcast-with-rebecca-bilbro.md
+++ b/content/en/resources/real-technologists-podcast-with-rebecca-bilbro.md
@@ -5,15 +5,12 @@ draft: false
 event_date: "2023-08-03"
 image: "img/resources/resource-image-for-podcasts.webp"
 name: "Real Technologists: Rebecca Bilbro"
-description: |
-  Dr. Rebecca Bilbro joins the [Real Technologists](https://realtechnologists.org/) podcast for an in-depth conversation about her career in data science. 
-  
-  [Listen here](https://realtechnologists.org/rebecca-bilbro/)
+description: Dr. Rebecca Bilbro joins the [Real Technologists](https://realtechnologists.org/) podcast for an in-depth conversation about her career in data science.
 events: ['Podcast']
 registration_link:
 call_to_action:
 video_link:
-audio_link: 
+audio_link: https://realtechnologists.org/rebecca-bilbro/
 categories: ['Audio']
 presenters: ['Rebecca Bilbro']
 topics: ['Career']

--- a/layouts/resources/single.html
+++ b/layouts/resources/single.html
@@ -27,7 +27,17 @@
         </div>
         {{ end }}
 
-        <section class="resource-description my-12 text-lg text-center">{{ .Params.description | .RenderString }}</section>
+        {{ if .Params.audio_link  }}
+        <section class="resource-description my-12 text-lg text-center">
+            {{ .Params.description | .RenderString }}
+            <p class="mt-4">
+              <a href="{{ .Params.audio_link }}" target="_blank">Listen here</a>
+            </p>
+        </section>
+        {{ else }}
+        <section class="resource-description my-12 text-lg">{{ .Params.description | .RenderString }}</section>
+        {{ end }}
+
 
         <section class="mb-14 p-8 text-center bg-[#E8EFF6] mx-auto max-w-[800px] rounded-lg">
             <section class="mb-6">


### PR DESCRIPTION
Scope of Changes:

- Adds YouTube link and description to the vector database webinar resource page. 
- Applies `text-center` only to resources with audio links, for now.

Fixes SC-23868

Acceptance Criteria:

https://tinyurl.com/2953jndw

https://tinyurl.com/242oh8b6