### PR TITLE
Add 3/12 webinar video link and description

### DIFF
--- a/content/en/resources/ai-for-non-technical-execs-taking-a-product-approach.md
+++ b/content/en/resources/ai-for-non-technical-execs-taking-a-product-approach.md
@@ -5,11 +5,21 @@ draft: false
 event_date: "2024-03-12T12:00:00-05:00"
 image: "img/resources/webinars/ai-for-non-technical-execs-taking-a-product-approach.webp"
 name: "AI for Non-Technical Execs: Taking a Product Approach"
-description: "Video Coming Soon!"
+description: |
+  Learn how to spot AI/ML use cases in the wild, no math required.
+
+  Are you a leader excited about the potential impact of AI for your business but have no idea where to start? Looking for opportunities around how gen AI can support you in solving a business question? Concerned about ROI? 
+
+  Designed specifically for non-technical decision-makers, this session focuses on de-mystifying AI and cultivating a "solutions-first" mindset, which includes:
+
+  - Identify your "y": In machine learning, we refer to our target (i.e. the outcome to predict) as our "y". Many data teams spin their wheels for months trying to determine the right target. Learn how to help them get there faster and ensure they're focused on solving the right problem from the get-go.
+  - Automate the boring stuff: While the rise of "quiet quitting" caused alarm for many organizations, it also marked a turning point in the evolution of work; many tasks that once relied on manual effort have become drivers of employee disengagement and churn. Learn which tasks are best suited to automation using AI/ML tools, as well as the ones a bot still can't do.
+  - Put the "face" back into interface: 87% percent of data science projects never make it to the intended end user. Whether that's an external or an internal customer, it's critical to design the AI interface before training the model to ensure it suits reality. Learn the best practices for these interfaces to ensure your team is designing with their end user in mind.
+
 events: ['Webinar']
 registration_link: https://r8l.co/XVq5jonHL5j
 call_to_action: "Register"
-video_link: 
+video_link: https://www.youtube.com/embed/8diFA0PSV0c?si=uVRJuM43fDhc1UoN
 audio_link: 
 categories: ['Video']
 presenters: ['Rebecca Bilbro']

--- a/content/en/resources/ai-for-non-technical-execs-taking-a-product-approach.md
+++ b/content/en/resources/ai-for-non-technical-execs-taking-a-product-approach.md
@@ -23,5 +23,5 @@ video_link: https://www.youtube.com/embed/8diFA0PSV0c?si=uVRJuM43fDhc1UoN
 audio_link: 
 categories: ['Video']
 presenters: ['Rebecca Bilbro']
-topics: ['AI']
+topics: ['AI', 'ML']
 ---


### PR DESCRIPTION
Scope of Changes:

Adds YouTube link and description to the AI for Non-Technical Execs webinar page.

Fixes SC-24074

Acceptance Criteria:
https://www.awesomescreenshot.com/video/25855009?key=29951225f4952a6d86342b72e53084e6