### PR TITLE
Use fa-brands for social icons

### DIFF
--- a/data/en/footer.yml
+++ b/data/en/footer.yml
@@ -50,16 +50,16 @@ footer:
     social_media:
     - name: Twitter
       link: https://twitter.com/rotationalio
-      icon: fa fa-twitter
+      icon: fa-brands fa-twitter
     - name: GitHub
       link: https://github.com/rotationalio
-      icon: fa fa-github
+      icon: fa-brands fa-github
     - name: LinkedIn
       link: https://www.linkedin.com/company/rotational
-      icon: fa fa-linkedin
+      icon: fa-brands fa-linkedin
     - name: YouTube
       link: https://www.youtube.com/@rotationalio
-      icon: fa fa-youtube
+      icon: fa-brands fa-youtube
     - name: Email
       link: mailto:info@rotational.io
       icon: fa fa-envelope

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -37,7 +37,7 @@ relative bg-[#1D65A6]">
                 {{ range .Params.social }}
                 <li><a href="{{ .link | absURL }}" target="_blank"
                         class="flex w-16 h-16 items-center  rounded-lg bg-sky-900 text-white">
-                        <i class="fab {{ .icon }} text-2xl mx-auto"></i>
+                        <i class="fa-brands {{ .icon }} text-2xl mx-auto"></i>
                     </a>
                 </li>
                 {{ end }}


### PR DESCRIPTION
Fixes bug that prevented social media icons from displaying in the footer.

Acceptance Criteria:
https://www.awesomescreenshot.com/image/47975978?key=a1941bd050e319d2b6bbf0c679fbd9d7

Fixes SC-25224