### PR TITLE
Display similar blog posts on single blog page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -152,6 +152,43 @@ baseName = "humans"
 isPlainText = true
 mediaType = "text/plain"
 
+[related]
+  includeNewer = true
+  threshold = 80
+  toLower = false
+  [[related.indices]]
+    applyFilter = false
+    cardinalityThreshold = 0
+    name = 'tags'
+    pattern = ''
+    toLower = false
+    type = 'basic'
+    weight = 100
+  [[related.indices]]
+    applyFilter = false
+    cardinalityThreshold = 0
+    name = 'date'
+    pattern = ''
+    toLower = false
+    type = 'basic'
+    weight = 10
+  [[related.indices]]
+    applyFilter = false
+    cardinalityThreshold = 0
+    name = 'authors'
+    pattern = ''
+    toLower = false
+    type = 'basic'
+    weight = 40
+  [[related.indices]]
+    applyFilter = false
+    cardinalityThreshold = 0
+    name = 'keywords'
+    pattern = ''
+    toLower = false
+    type = 'basic'
+    weight = 80
+
 [taxonomies]
   tag = 'tags'
   author = 'authors'

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -23,7 +23,7 @@
         <div class="flex justify-between items-center px-6 py-3 border-t mt-6 xl:mt-8">
             <div class="flex items-center">
                 {{ $profile := .Params.profile }}
-                {{ if eq (len .Params.authors) 1}}
+                {{ if eq .Params.authors 1 }}
                 {{ range .Params.authors }}
                 <a href="/authors/{{ . | urlize }}" class="flex items-center">
                     <img src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
@@ -31,7 +31,7 @@
                 </a>
                 {{ end }}
                 {{ else }}
-                <img src="{{ .Params.profile }}" alt="" class="rounded-full h-10 w-10">
+                <img src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
                 <ul class="flex flex-wrap ml-4">
                     {{ range $key, $value := .Params.authors }}
                     <li class="font-extralight">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -110,7 +110,7 @@
       <div class="flex items-center">
         <h2 class="font-bold text-2xl sm:text-4xl flex">
           <span class="text-[#1D65A6]">Recommended</span>
-          Rotations
+          &nbsp;Rotations
         </h2>
         <img src="img/butterfly.png" alt="butterfly" class="ml-4 h-6 sm:h-8">
       </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -109,13 +109,15 @@
     <div class="flex justify-between mt-12 sm:mt-24 items-center">
       <div class="flex items-center">
         <h2 class="font-bold text-2xl sm:text-4xl flex">
-          <span class="text-[#1D65A6]">Recommended</span>&nbsp;Rotations
+          <span class="text-[#1D65A6]">Recommended</span>
+          Rotations
         </h2>
         <img src="img/butterfly.png" alt="butterfly" class="ml-4 h-6 sm:h-8">
       </div>
       <div>
         <a href="/blog" class="flex text-base sm:text-lg items-center font-bold text-[#1D65A6]"><span>View all</span>
-          <img src="img/arr-right.png" alt="" class="h-4 ml-2"></a>
+          <img src="img/arr-right.png" alt="" class="h-4 ml-2">
+        </a>
       </div>
     </div>
     <div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -122,7 +122,8 @@
     </div>
     <div>
       <div class="grid lg:grid-cols-2 xl:grid-cols-3 gap-8 sm:mt-16">
-        {{ range first 3 (where site.RegularPages "Section" "==" "blog")}}
+        {{ $related := (where (.Site.RegularPages.Related .) "Type" "blog") | first 3 }}
+        {{ range ($related.ByParam "date").Reverse }}
         <div class="mt-6 ">
           {{ .Render "article"}}
         </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -107,14 +107,12 @@
 
   <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
     <div class="flex justify-between mt-12 sm:mt-24 items-center">
-      <h2 class="font-bold text-2xl sm:text-4xl flex">
-        <span>
-          <b class="text-[#1D65A6]">{{ with i18n "blogTitle" }} {{ index (split . " ") 0 | safeHTML }} {{ end }}</b>
-          {{ with i18n "blogTitle" }} {{ after (len (index (split . " ") 0)) . | safeHTML }} {{ end }}
-
-        </span>
-        <img src="img/butterfly.png" alt="butterfly" class="ml-4 h-6 sm:h-8 relative top-1">
-      </h2>
+      <div class="flex items-center">
+        <h2 class="font-bold text-2xl sm:text-4xl flex">
+          <span class="text-[#1D65A6]">Recommended</span>&nbsp;Rotations
+        </h2>
+        <img src="img/butterfly.png" alt="butterfly" class="ml-4 h-6 sm:h-8">
+      </div>
       <div>
         <a href="/blog" class="flex text-base sm:text-lg items-center font-bold text-[#1D65A6]"><span>View all</span>
           <img src="img/arr-right.png" alt="" class="h-4 ml-2"></a>

--- a/static/output.css
+++ b/static/output.css
@@ -1611,6 +1611,10 @@ video {
   width: 1rem;
 }
 
+.w-48 {
+  width: 12rem;
+}
+
 .w-56 {
   width: 14rem;
 }
@@ -3802,10 +3806,6 @@ em {
     height: 380px;
   }
 
-  .lg\:h-auto {
-    height: auto;
-  }
-
   .lg\:w-1\/2 {
     width: 50%;
   }
@@ -3815,10 +3815,6 @@ em {
   }
 
   .lg\:w-2\/3 {
-    width: 66.666667%;
-  }
-
-  .lg\:w-8\/12 {
     width: 66.666667%;
   }
 


### PR DESCRIPTION
Scope of Changes:

This PR uses parameters set in a blog post's frontmatter to display similar posts. This [page](https://gohugo.io/content-management/related/) explains how Hugo identifies related content.

Note: I noticed some of the blog posts appear slightly longer than others and will handle that in a follow on story.

Acceptance Criteria:

https://www.awesomescreenshot.com/video/29181749?key=cf4a2cab026289f2de9e90e523fd0ce9