### PR TITLE
Add bg color to list element

### DIFF
--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -57,7 +57,7 @@ relative bg-[#1D65A6]">
         <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-6 md:gap-8">
             {{ $paginator := .Paginate .Data.Pages 6 }}
             {{ range $paginator.Pages }}
-            <li class="mt-6 sm:mt-0 h-auto">
+            <li class="mt-6 sm:mt-0 h-auto rounded-b-xl bg-[#ECF6FF]">
                 {{ .Render "article" }}
             </li>
             {{ end }}


### PR DESCRIPTION
This PR adds a bg color to a list element to ensure the blog posts on the author pages appear to be the same height. It also rounds the bottom border to be consistent with how blog posts appear on the blog page.

Acceptance Criteria:
https://www.awesomescreenshot.com/video/30726047?key=fc86214e0e549adbd657fdd41fbede73