### PR TITLE
Correct alias link

### DIFF
--- a/content/en/resources/2024-07-30-demystifying-llms.md
+++ b/content/en/resources/2024-07-30-demystifying-llms.md
@@ -1,7 +1,7 @@
 ---
 title: "Demystifying Hugging Face Models & How to Leverage Them For Business Impact"
 slug: "demystifying-hugging-face-models"
-aliases: /demystifying-llms
+aliases: /resources/demystifying-llms
 draft: false
 event_date: "2024-07-30T13:00:00-05:00"
 image: "img/resources/webinars/2024-07-30-demystifying-llms/demystifying-hugging-face-models.webp"


### PR DESCRIPTION
This corrects an alias link for the `Demystifying Hugging Face Models" resource page.