### PR TITLE
Remove services link from footer and update learning link

### DIFF
--- a/data/en/footer.yml
+++ b/data/en/footer.yml
@@ -18,8 +18,6 @@ footer:
     company_items:
     - name: About Us
       link: /about
-    - name: Services
-      link: /services
     - name: Case Studies
       link: /case-studies
     - name: Endeavor
@@ -33,7 +31,7 @@ footer:
     title: COMMUNITY
     info_items:
     - name: Learning
-      link: /resources
+      link: /learning
     - name: Open Source
       link: /opensource
 

--- a/layouts/data-playground/list.html
+++ b/layouts/data-playground/list.html
@@ -43,5 +43,5 @@
 
 {{ define "appcode" }}
     <script src="https://unpkg.com/lunr/lunr.js"></script>
-    <script src="{{ `js/dataPlayground.js` | absURL }}"></script>
+    <script src="{{ `js/dataPlaygroundList.js` | absURL }}"></script>
 {{ end }}


### PR DESCRIPTION
This PR removes a link to the `/services` page from the footer, updates the link for the Learning page from `/resources` to `/learning`, and corrects the JS file name on the Data Playground page.