### PR TITLE
Amend copy and fix blog errors

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -79,7 +79,7 @@ weight = 5
 [[Languages.en.menu.main]]
 identifier = 'Endeavor'
 pageRef = 'endeavor'
-name = 'Endeavor'
+name = 'Product'
 weight = 6
 
 [[Languages.en.menu.main]]

--- a/data/en/endeavor.yml
+++ b/data/en/endeavor.yml
@@ -19,5 +19,5 @@ endeavor:
         - benefit: '<span class="font-bold">Improved Efficiency</span>: Automate the entire AI lifecycle, from data gathering to monitoring, reducing time and resource costs.'
         - benefit: '<span class="font-bold">Enhanced Governance</span>: Ensure compliance and trusted AI use with built-in tools for transparency and accountability.'
         - benefit: '<span class="font-bold">Customizable for Your Use Cases</span>: Tailor AI models specifically to your unique needs and operational challenges.'
-  cta: "Join our waitlist:"
+  cta: "Schedule a Consultation:"
   previewimage: "img/endeavor-dashboard-preview.webp"

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -1,5 +1,7 @@
 <div class="flex flex-col h-full">
     <a href="{{ .Permalink }}">
+
+        {{ if .Params.image }}
         {{ $image := .Params.image }}
         {{ $img := resources.Get $image }}
         {{ $img := $img.Resize "640x" }}
@@ -7,6 +9,7 @@
         {{ $webp := $img.Process "resize 640x webp q80" }}    
         <img loading="lazy" src="{{ if ne $img.MediaType.SubType "webp" }}{{ $webp.RelPermalink }}{{ else }}{{ $img.RelPermalink }}{{ end }}" 
               alt="" class="rounded-t-xl object-cover" style="height:212px;width:100%" />
+              {{ end }}
     </a>
     <div class="px-4 pt-4">
         <ul class="flex flex-wrap">
@@ -30,18 +33,16 @@
     <div class="flex justify-between mt-auto items-center border-t px-4 py-3 h-16">
         <div class="flex items-center">
             {{ $profile := .Params.profile }}
-            {{ $profile := resources.Get $profile }}
-            {{ $profile := $profile.Process "resize 40x40 webp q80" }}
 
             {{ if eq .Params.authors 1 }}
             {{ range .Params.authors }}
             <a href="/authors/{{ . | urlize }}" class="flex items-center">
-                <img loading="lazy" src="{{ $profile.RelPermalink }}" alt="" class="rounded-full">
+                <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full">
                 <span class="ml-4 font-extralight">{{ . }}</span>
             </a>
             {{ end }}
             {{ else }}
-            <img loading="lazy" src="{{ $profile.RelPermalink }}" alt="" class="rounded-full">
+            <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full">
             <ul class="flex flex-wrap ml-4">
                 {{ range $key, $value := .Params.authors }}
                 <li class="font-extralight">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -12,6 +12,7 @@
 {{ define "main" }}
 <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
   <div class="mt-14">
+    {{ if .Params.image }}
     {{ $image := .Params.image }}
     {{ $img := resources.Get $image }}
     {{ $img := $img.Resize "640x" }}
@@ -22,7 +23,7 @@
       <img src="{{ if ne $img.MediaType.SubType "webp" }} {{ $webp.RelPermalink }} {{ else }} {{ $img.RelPermalink }} {{ end }}" 
           alt="{{ .Title }}" class="mx-auto object-cover">
     </div>
-
+    {{ end }}
 
 
     <div class="mt-8">


### PR DESCRIPTION
Scope of Changes:
- Change "Endeavor" to "Product" in the navigation bar
- Update copy on the Endeavor page above form. Note: The form will be updated in a future story to match HubSpot.
- Resize blog post images only if they exist to resolve error
- Remove resizing of blog post author images. An error also occurred if the file name wasn't updated in the frontmatter. Instead of Hugo resizing the image for each blog post, it will be better to resize the images and store them in the img directory. This will also be handled in a follow on story.