### PR TITLE
Add width and height back to blog author images

### DIFF
--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -37,12 +37,12 @@
             {{ if eq .Params.authors 1 }}
             {{ range .Params.authors }}
             <a href="/authors/{{ . | urlize }}" class="flex items-center">
-                <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full">
+                <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
                 <span class="ml-4 font-extralight">{{ . }}</span>
             </a>
             {{ end }}
             {{ else }}
-            <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full">
+            <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
             <ul class="flex flex-wrap ml-4">
                 {{ range $key, $value := .Params.authors }}
                 <li class="font-extralight">


### PR DESCRIPTION
Scope of Changes:
This PR adds height and width values back to the blog author image so that the images don't appear too large and outside the container. The style was previously removed when it was decided to use Hugo's `Resize` method to adjust the images. 

The `Resize` method was removed after deciding to create smaller versions of the author photos instead of resizing them each time a blog post was added, but the height and width styles weren't added at the time. The changes here will fix that.

Acceptance Criteria:
https://www.awesomescreenshot.com/video/34218838?key=8efb8003b19a55f61b60c9c957c930df