### PR TITLE
Add recaptcha to contact form

### DIFF
--- a/layouts/contact/single.html
+++ b/layouts/contact/single.html
@@ -29,21 +29,23 @@
                     {{ with .title }} {{ index (split . " ") 0 | safeHTML }} {{ end }}
                     {{ with .title }} {{ after (len (index (split . " ") 0)) . | safeHTML }} {{ end }}
                 </h5>
-                <div class="mt-4 lg:ml-6">
-                    <div class="bg-teal-100 border-t-4 border-teal-500 rounded-b text-teal-900 px-4 py-3 shadow-md hidden"
-                        id='contact-alert' role="alert">
-                        <div class="flex">
+                <div class="mt-2 lg:ml-6">
+                    <div id="contact-alert" class="bg-teal-100 border-t-4 border-teal-500 rounded-b text-teal-900 px-4 py-3 mb-3 shadow-md hidden" role="alert">
+                        <div>
+                            <p class="font-bold">{{site.Params.contactFormSuccessTitle}} </p>
+                            <p class="text-sm">{{site.Params.contactFormSuccessMessage}}</p>
+                        </div>
+                    </div>
 
-                            <div>
-                                <p class="font-bold">{{site.Params.contactFormSuccessTitle}} </p>
-                                <p class="text-sm">{{site.Params.contactFormSuccessMessage}}</p>
-                            </div>
+                    <div id="contact-error" class="hidden bg-red-200 border-t-4 border-red-600 text-red-900 rounded-b p-4 mb-4 shadow-md" role="alert">
+                        <div>
+                            <p class="text-sm">{{site.Params.contactFormErrorMessage}}</p>
                         </div>
                     </div>
 
                     <input type="hidden" id="formID" value="e1bf5b24-ab7f-49f1-bcdc-bb389b28bec5">
                     <form action="contact" method="post" id="contactForm">
-                        <div class="lg:flex lg:gap-x-6">
+                        <div class="pt-2 lg:flex lg:gap-x-6">
                             <label for="first_name" class="hidden">First Name</label>
                             <input type="text" name='first_name' id="first_name" required placeholder="{{ .firstname }}" class="input-sl">
                             <label for="last_name" class="hidden">Last Name</label>
@@ -60,7 +62,7 @@
                             <input type="text" name='organization' id="organization" required placeholder="{{ .organization }}" class="input-sl">
                         </div>
                         <label for="message" class="hidden">Message</label>
-                        <textarea name="message" required placeholder="{{ .message }}" id="message" cols="30" rows="4"
+                        <textarea name="message" placeholder="{{ .message }}" id="message" cols="30" rows="4"
                             class="input-sl"></textarea>
                         <div class="flex mt-4 items-base">
                             <input type="checkbox" id="checkbox" required name="consent" class="w-4 h-4 mt-1 border-0">

--- a/layouts/contact/single.html
+++ b/layouts/contact/single.html
@@ -101,5 +101,5 @@
 {{ end }}
 
 {{ define "appcode" }}
-<script src="{{ `js/contact.js` | absURL }}"></script>
+<script type="module" src="{{ `js/contact.js` | absURL }}"></script>
 {{ end }}

--- a/layouts/contact/single.html
+++ b/layouts/contact/single.html
@@ -67,7 +67,7 @@
                             <label for="checkbox"><span class="ml-2 text-white" id="consentText">{{ .subscribe_consent_text }}</span></label>
                         </div>
                         <div class="md:flex items-center justify-between mt-6 text-center md:mt-7 lg:mt-8">
-                            <button type="submit" class="flex mr-9 bg-white mt-6 px-7 py-4 rounded-lg hover:bg-white/90">{{.submit }}</button>
+                            <button id="contact-bttn" type="submit" data-sitekey="{{ .Site.Params.recaptchaKey }}" data-action="contact" class="flex mr-9 bg-white mt-6 px-7 py-4 rounded-lg hover:bg-white/90">{{.submit }}</button>
                         </div>
 
                     </form>

--- a/layouts/partials/site-head.html
+++ b/layouts/partials/site-head.html
@@ -50,13 +50,18 @@
 
 {{- if .Site.Params.googleAnalytics -}}
 {{ "<!-- Google Analytics -->" | safeHTML }}
-<script src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.googleAnalytics }}" defer></script>
+<script src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.googleAnalytics }}" async defer></script>
 <script type="module">
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
   gtag('js', new Date());
   gtag('config', '{{ .Site.Params.googleAnalytics }}');
 </script>
+{{ end }}
+
+{{- if .Site.Params.recaptchaKey -}}
+{{ "<!-- Google RECAPTCHA -->" | safeHTML }}
+<script async defer src="https://www.google.com/recaptcha/enterprise.js?render={{ .Site.Params.recaptchaKey }}"></script>
 {{ end }}
 
 {{ if site.Params.plugins.js }}

--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -6,15 +6,3 @@
 {{ "<!-- HubSpot Code -->" | safeHTML }}
 <script type="text/javascript" id="hs-script-loader" async defer src="{{ .Site.Params.hubspotCode }}"></script>
 {{ end }}
-
-{{- if .Site.Params.recaptchaKey -}}
-{{ "<!-- Google RECAPTCHA -->" | safeHTML }}
-<script src="https://www.google.com/recaptcha/enterprise.js?render={{.Site.Params.recaptchaKey}}"></script>
-<script>
-  grecaptcha.enterprise.ready(function () {
-    grecaptcha.enterprise.execute('{{ .Site.Params.recaptchaKey }}', { action: 'homepage' }).then(function (token) {
-      // Add your logic to submit to your backend server here.
-    });
-  });
-</script>
-{{ end }}

--- a/static/js/contact.js
+++ b/static/js/contact.js
@@ -3,6 +3,7 @@ import { fetchAssessment } from "./recaptchaAssessment.js";
 // Contact Form submission
 const form = document.getElementById('contactForm');
 const formID = document.getElementById('formID');
+const errorEl = 'contact-error';
 
 form?.addEventListener('submit', (event) => {
   event.preventDefault();
@@ -14,17 +15,17 @@ form?.addEventListener('submit', (event) => {
   
   const assessment = fetchAssessment(siteKey, action);
 
-  // TODO: Display error message in the form.
   if (!assessment) {
     console.error('Unable to submit form');
+    setError(form, errorEl);
     return;
   }
 
   // If the risk analysis score is less than 0.5, do not submit the form.
   // There is a high probability that the request is spam.
-  // TODO: Display error message in the form.
   if (assessment?.riskAnalysis?.score < 0.5) {
     console.error('Unable to submit form');
+    setError(form, errorEl);
     return;
   }
 
@@ -55,11 +56,11 @@ form?.addEventListener('submit', (event) => {
         document.getElementById('contact-alert').style.display = 'block';
         form.reset();
 
-        // Hide contact form submission confirmation message after 10 seconds.
+        // Hide contact form submission confirmation message after 5 seconds.
         setTimeout(() => {
           const contactAlert = document.getElementById('contact-alert');
           contactAlert.style.display = 'none';
-        }, 10000);
+        }, 5000);
       }
       return response.json();
     })
@@ -69,5 +70,20 @@ form?.addEventListener('submit', (event) => {
 
     .catch((error) => {
       console.error('Error:', error);
+      setError(form, errorEl)
     });
 });
+
+// Display error message if form submission fails.
+function setError(formName, errorEl) {
+  document.getElementById(errorEl).style.display = 'block';
+  formName?.reset();
+
+  // Hide error message after 5 seconds.
+  setTimeout(() => {
+    const errorAlert = document.getElementById(errorEl);
+    errorAlert.style.display = 'none';
+  }, 5000);
+
+  return;
+}

--- a/static/js/reCAPTCHA.js
+++ b/static/js/reCAPTCHA.js
@@ -1,6 +1,0 @@
-export function getRecaptchaToken(key, action) {
-  grecaptcha.enterprise.ready(async () => {
-    const token = await grecaptcha.enterprise.execute(key, { action: action });
-    return token;
-  })
-}

--- a/static/js/reCAPTCHA.js
+++ b/static/js/reCAPTCHA.js
@@ -1,0 +1,6 @@
+export function getRecaptchaToken(key, action) {
+  grecaptcha.enterprise.ready(async () => {
+    const token = await grecaptcha.enterprise.execute(key, { action: action });
+    return token;
+  })
+}

--- a/static/js/recaptchaAssessment.js
+++ b/static/js/recaptchaAssessment.js
@@ -1,0 +1,40 @@
+// Get reCAPTCHA token after form submission and return an assessment score
+// to help determine if request is spam or not.
+export function fetchAssessment(siteKey, action) {
+  const token = fetchRecaptchaToken(siteKey, action);
+
+  if (!token) {
+    console.error('invalid recaptcha token');
+    return;
+  }
+
+  const req = {}
+  req.token = token;
+  req.action = action;
+
+  fetch(`https://api.rotationallabs.com/v1/recaptcha`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(req),
+  })
+    .then((response) => {
+      return response.json();
+    })
+    .then((data) => {
+      console.log('Success:', data);
+      return data;
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+    });
+};
+
+// Get the recaptcha token from the reCAPTCHA Enterprise API.
+function fetchRecaptchaToken(key, action) {
+  grecaptcha.enterprise.ready(async () => {
+    const token = await grecaptcha.enterprise.execute(key, { action: action });
+    return token;
+  });
+};


### PR DESCRIPTION
Scope of Changes:
This story attempts to complete the reCAPTCHA implementation on the site starting with the contact form. Going forward, when a user submits a form, we will make a call to the backend that will provide an analysis score. If the score determines that a form submission is likely spam, it will not be submitted.

Acceptance Criteria:
Test of the contact form submission failing. Once the change is deployed, I'll be able to test the happy path.
https://www.awesomescreenshot.com/video/34599741?key=69e0ed897d1fdf194897ac5e9c86cbb7
