### PR TITLE
Update blog link in privacy section and add link to DPF site

### DIFF
--- a/data/en/alerts.yml
+++ b/data/en/alerts.yml
@@ -1,6 +1,6 @@
 ############################# Ensign Data ###################################
 notice:
-  enable: true
+  enable: false
   notice: "Privacy & Security in the Gen AI Era"
   action:
     text: Register Now

--- a/data/en/privacy.yml
+++ b/data/en/privacy.yml
@@ -3,6 +3,10 @@ privacy:
   tagline: OUR PRIORITY
   title: PRIVACY & SECURITY
   description: Rotational is deeply committed to privacy and security. AI offers tremendous potential benefit to humanity, provided it is used properly, and enterprises commit to being good data stewards. To that end, we have committed to the US-EU Data Privacy Framework (DPF) and prioritize privacy and security in all our product and services work.
+  image: img/security_and_privacy.webp
   button:
     text: LEARN MORE
-    url: blog/data-access-controls-for-generative-ai/
+    url: blog/rotational-joins-eu-us-data-privacy-framework-to-strengthen-privacy-commitment/
+  dpf:
+    url: https://www.dataprivacyframework.gov/
+    logo: img/dpf-program-logo.png

--- a/layouts/shortcodes/privacy.html
+++ b/layouts/shortcodes/privacy.html
@@ -5,7 +5,7 @@
 
 <section class="max-w-7xl w-full mx-auto py-14 px-4 sm:px-6 grid lg:grid-cols-2 gap-12 lg:gap-24">
   <section class="mx-auto">
-    <img loading="lazy" src="img/security_and_privacy.webp" alt="" class="h-auto w-full" />
+    <img loading="lazy" src="{{ .image }}" alt="" class="h-auto w-full" />
   </section>
   <section class="mx-auto">
     <h5 class="font-bold text-[#757575]">{{ .tagline }}</h5>
@@ -13,7 +13,7 @@
     <p class="my-4 md:text-lg">{{ .description }}</p>
     <div class="py-4 flex items-center gap-x-16">
       <a href="{{ .button.url }}" class="py-4 px-4 sm:px-6 bg-[#2F4858] font-bold text-white text-center hover:bg-[#2F4858]/80">{{ .button.text }}</a>
-      <img src="img/dpf-program-logo.png" alt="" class="h-[3.75rem] w-auto" />
+      <a href="{{ .dpf.url }}" target="_blank"><img src="{{ .dpf.logo }}" alt="" class="h-[3.75rem] w-auto" /></a>
     </div>
   </section>
 </section>


### PR DESCRIPTION
Scope of Changes:
This PR adds a link to the `DPF` logo on the home page. It also amends the `Learn More` link to a blog post about Rotational joining the DPF.

Acceptance Criteria: 
https://www.awesomescreenshot.com/video/34555276?key=41e9c875358fb07ad01ad578f34db230