### PR TITLE
Resize blog author images

### DIFF
--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -32,17 +32,21 @@
     </div>
     <div class="flex justify-between mt-auto items-center border-t px-4 py-3 h-16">
         <div class="flex items-center">
-            {{ $profile := .Params.profile }}
+            {{ if .Params.profile }}
+            {{ $profile := resources.Get .Params.profile }}
+            
+            {{ if $profile }}
+            {{ $resizedImg := $profile.Resize "40x40" }}
 
             {{ if eq .Params.authors 1 }}
             {{ range .Params.authors }}
             <a href="/authors/{{ . | urlize }}" class="flex items-center">
-                <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
+                <img loading="lazy" src="{{ $resizedImg.RelPermalink }}" alt="" class="rounded-full h-10 w-10">
                 <span class="ml-4 font-extralight">{{ . }}</span>
             </a>
             {{ end }}
             {{ else }}
-            <img loading="lazy" src="{{ $profile }}" alt="" class="rounded-full h-10 w-10">
+            <img loading="lazy" src="{{ $resizedImg.RelPermalink }}" alt="" class="rounded-full h-10 w-10">
             <ul class="flex flex-wrap ml-4">
                 {{ range $key, $value := .Params.authors }}
                 <li class="font-extralight">
@@ -50,6 +54,8 @@
                 </li>
                 {{ end }}
             </ul>
+            {{ end }}
+            {{ end }}
             {{ end }}
         </div>
         <div class="font-extralight">


### PR DESCRIPTION
Scope of Changes:
This PR will resize a blog post author's image. We previously reversed this change after running into errors if the frontmatter didn't display an image that exists. The change now checks to see if the image is in the resources directory before resizing it.

Acceptance Criteria:
Create a test blog post. Without making any changes to the frontmatter, run the server with the `hugo serve -D` command. The site should build successfully and you should be able to navigate to the local version of the site.