### PR TITLE
Replace webinar shortlink

### DIFF
--- a/data/en/alerts.yml
+++ b/data/en/alerts.yml
@@ -4,5 +4,5 @@ notice:
   notice: "Join us for our Pre-training LLMs Tutorial on Feb 28"
   action:
     text: Learn More
-    link: "https://r8l.co/xZEhstjXPMn"
+    link: "https://events.rotational.io/llm-tutorial"
   expires: 2025-02-28T16:00:00Z


### PR DESCRIPTION
This PR replaces the shortlink used for the webinar registration so that users will not see a privacy error in the browser.