### PR TITLE
Hide manage cookies button and script

### DIFF
--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -96,11 +96,11 @@
                     <ul class="sm:mt-0 mt-4 flex gap-x-8">
                         <li><a href="/privacy/">{{ i18n "privacyPolicy" }}</a></li>
                         <li><a href="/terms/">{{ i18n "termsOfUse" }}</a></li>
-                        <li>
+                      <!--   <li>
                             <button id="hs_show_banner_button" class="cookie-bttn" type="button">
                                 {{ i18n "manageCookies" }}
                             </button>
-                        </li>
+                        </li> -->
                     </ul>
                 </div>
             </div>

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -15,9 +15,10 @@ if (emblaRoot) {
   });
 };
 
+// TODO: Debug cookie banner script.
 // Display cookie banner on user click.
-const cookieBttn = document.querySelector('.cookie-bttn');
+/* const cookieBttn = document.querySelector('.cookie-bttn');
 cookieBttn?.addEventListener('click', () => {
   const _hsp = window._hsp = window._hsp || [];
   _hsp.push(['showBanner']);
-})();
+})(); */


### PR DESCRIPTION
This PR temporarily hides the Manage Cookies button until a bug preventing it from working is resolved.