### PR TITLE
Change consent function variable name

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -146,5 +146,5 @@
 
 {{ define "appcode" }}
 <script src="{{ `js/blogSingle.js` | absURL }}"></script>
-<script src="{{ `js/newsletterForm.js` | absURL }}"></script>
+<script type="module" src="{{ `js/newsletterForm.js` | absURL }}"></script>
 {{ end }}

--- a/layouts/partials/site-head.html
+++ b/layouts/partials/site-head.html
@@ -69,8 +69,8 @@
     'personalization_storage': 'denied',
   })
 
-  const _hsp = window._hsp = window._hsp || [];
-  _hsp.push(['addPrivacyConsentListener', function(consent) {
+  const hspConsent = window._hsp = window._hsp || [];
+  hspConsent.push(['addPrivacyConsentListener', function(consent) {
     const hasAnalyticsConsent = consent && (consent.allowed  || (consent.categories && consent.categories.analytics));
     const hasAdsConsent = consent && (consent.allowed || (consent.categories && consent.categories.advertisement));
     const hasFunctionalityConsent = consent && (consent.allowed || (consent.categories && consent.categories.functionality));


### PR DESCRIPTION
This PR fixes a syntax error in the Google consent script that is caused by a variable that's previously declared via a separate HubSpot script.

The newsletter form script file is also amended to be a module so that it may work with import statements.