### PR TITLE
Send hutk and conversion page details with form submissions

### DIFF
--- a/static/js/contact.js
+++ b/static/js/contact.js
@@ -1,4 +1,5 @@
 import { /* fetchAssessment, passAssessment, */ setError } from "./recaptchaAssessment.js";
+import { getHubspotCookie } from "./utils.js";
 
 // Contact Form submission
 const form = document.getElementById('contactForm');
@@ -49,6 +50,10 @@ form?.addEventListener('submit', async (event) => {
   // Add consent text to the data object.
   const consentText = document.getElementById('consentText');
   data.consent_text = consentText?.innerText;
+
+  // Get HubSpot tracking cookie.
+  const hutk = getHubspotCookie();
+  data.hutk = hutk;
 
   fetch(`https://api.rotationallabs.com/v1/contact/form/${formID?.value}`, {
     method: 'POST',

--- a/static/js/contact.js
+++ b/static/js/contact.js
@@ -53,7 +53,10 @@ form?.addEventListener('submit', async (event) => {
 
   // Get HubSpot tracking cookie.
   const hutk = getHubspotCookie();
-  data.hutk = hutk;
+  
+  if (hutk) {
+    data.hutk = hutk;
+  }
 
   fetch(`https://api.rotationallabs.com/v1/contact/form/${formID?.value}`, {
     method: 'POST',

--- a/static/js/endeavor.js
+++ b/static/js/endeavor.js
@@ -50,7 +50,10 @@ endeavorForm?.addEventListener('submit', async (event) => {
 
   // Get HubSpot tracking cookie.
   const hutk = getHubspotCookie();
-  data.hutk = hutk;
+  
+  if (hutk) {
+    data.hutk = hutk;
+  }
 
   fetch(`https://api.rotationallabs.com/v1/contact/form/${formID?.value}`, {
     method: 'POST',

--- a/static/js/endeavor.js
+++ b/static/js/endeavor.js
@@ -1,4 +1,5 @@
 import { /* fetchAssessment, passAssessment, */ setError } from "./recaptchaAssessment.js";
+import { getHubspotCookie } from "./utils.js";
 
 // Submit Endeavor form
 const endeavorForm = document.getElementById('endeavorForm');
@@ -46,6 +47,10 @@ endeavorForm?.addEventListener('submit', async (event) => {
    // Add consent text to the data object.
   const consentText = document.getElementById('consentText');
   data.consent_text = consentText?.innerText;
+
+  // Get HubSpot tracking cookie.
+  const hutk = getHubspotCookie();
+  data.hutk = hutk;
 
   fetch(`https://api.rotationallabs.com/v1/contact/form/${formID?.value}`, {
     method: 'POST',

--- a/static/js/newsletterForm.js
+++ b/static/js/newsletterForm.js
@@ -25,13 +25,13 @@ newsletterForm?.addEventListener('submit', (event) => {
   // Get the tracking cookie.
   const hutk = getHubspotCookie();
   
+  // Verify the cookie exists before adding it to the data object. If it exists, send the conversion page details. 
+  // HubSpot will return a 404 if the hutk isn't included with the page URI and page name.
   if (hutk) {
     data.hutk = hutk;
+    data.page_uri = window.location.href;
+    data.page_name = document.title;
   }
-
-  // Get the conversion page details.
-  data.page_uri = window.location.href;
-  data.page_name = document.title;
 
   fetch(`https://api.rotationallabs.com/v1/contact/form/${formID?.value}`, {
     method: 'POST',

--- a/static/js/newsletterForm.js
+++ b/static/js/newsletterForm.js
@@ -1,4 +1,5 @@
 import { setError } from "./recaptchaAssessment.js";
+import { getHubspotCookie } from "./utils.js";
 
 //  newsletter form submission
 const newsletterForm = document.getElementById('newsletterForm');
@@ -21,6 +22,11 @@ newsletterForm?.addEventListener('submit', (event) => {
   const consentText = document.getElementById('consentText');
   data.consent_text = consentText?.innerText;
 
+  // Get the tracking cookie and conversion page details.
+  const hutk = getHubspotCookie();
+  data.hutk = hutk;
+  data.page_uri = window.location.href;
+  data.page_name = document.title;
 
   fetch(`https://api.rotationallabs.com/v1/contact/form/${formID?.value}`, {
     method: 'POST',
@@ -50,3 +56,4 @@ newsletterForm?.addEventListener('submit', (event) => {
       setError(newsletterForm, errorEl)
     });
 });
+

--- a/static/js/newsletterForm.js
+++ b/static/js/newsletterForm.js
@@ -22,9 +22,14 @@ newsletterForm?.addEventListener('submit', (event) => {
   const consentText = document.getElementById('consentText');
   data.consent_text = consentText?.innerText;
 
-  // Get the tracking cookie and conversion page details.
+  // Get the tracking cookie.
   const hutk = getHubspotCookie();
-  data.hutk = hutk;
+  
+  if (hutk) {
+    data.hutk = hutk;
+  }
+
+  // Get the conversion page details.
   data.page_uri = window.location.href;
   data.page_name = document.title;
 

--- a/static/js/newsletterForm.js
+++ b/static/js/newsletterForm.js
@@ -26,7 +26,7 @@ newsletterForm?.addEventListener('submit', (event) => {
   const hutk = getHubspotCookie();
   
   // Verify the cookie exists before adding it to the data object. If it exists, send the conversion page details. 
-  // HubSpot will return a 404 if the hutk isn't included with the page URI and page name.
+  // HubSpot will return a 400 if the hutk isn't included with the page URI and page name.
   if (hutk) {
     data.hutk = hutk;
     data.page_uri = window.location.href;

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,3 +1,4 @@
+// Get the HubSpot tracking cookie from the browser to be included in the form submission data.
 export function getHubspotCookie() {
   return document.cookie.replace(/(?:(?:^|.*;\s*)hubspotutk\s*\=\s*([^;]*).*$)|^.*$/, "$1");
 }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,4 +1,4 @@
 // Get the HubSpot tracking cookie from the browser to be included in the form submission data.
 export function getHubspotCookie() {
-  return document.cookie.replace(/(?:(?:^|.*;\s*)hubspotutk\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+  return document.cookie.split("; ").find((row) => row.startsWith("hubspotutk="))?.split("=")[1];
 }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,3 @@
+export function getHubspotCookie() {
+  return document.cookie.replace(/(?:(?:^|.*;\s*)hubspotutk\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+}


### PR DESCRIPTION
This PR updates the newsletter form (homepage and single blog post page form) submission to include the page a user is on when submitting the form. It also updates all forms to include the tracking cookie data, if it exists, on submission.

Note: This PR should be merged after the changes in [this PR](https://github.com/rotationalio/api.rotational.io/pull/4) are merged and deployed.