### PR TITLE
Fix bug in recaptcha assessment and enable recaptcha for forms

### DIFF
--- a/layouts/partials/newsletterForm.html
+++ b/layouts/partials/newsletterForm.html
@@ -1,7 +1,7 @@
 <div class="bg-[#1D65A6] max-w-[800px] mx-auto mt-20 py-8 px-12 md:px-16 text-white md:rounded-lg">
 
   <input type="hidden" id="newsletterFormID" value="8aeeb77b-a5e0-4772-b726-44e1fc2eb6e1">
-  <form action="blog" method="post" id="newsletterForm">
+  <form action="newsletter" method="post" id="newsletterForm">
     <h6 class="font-bold text-center">{{ i18n "enterEmailToSubscribe" }}</h6>
 
     <div class="bg-teal-100 border-t-4 border-teal-500 mt-3 rounded-b text-teal-900 p-4 shadow-md hidden "
@@ -29,7 +29,7 @@
     </div>
     <div class="flex justify-center">
 
-      <button type="submit" class="bg-[#192E5B] px-10 py-3 mt-8 rounded-lg text-sm text-white uppercase md:text-base hover:bg-[#192E5B]/80">
+      <button id="newsletter-bttn" type="submit" data-sitekey="{{ site.Params.recaptchaKey }}" data-action="newsletter" class="bg-[#192E5B] px-10 py-3 mt-8 rounded-lg text-sm text-white uppercase md:text-base hover:bg-[#192E5B]/80">
         {{ i18n
         "submit" }}</button>
     </div>

--- a/static/js/contact.js
+++ b/static/js/contact.js
@@ -1,4 +1,4 @@
-import { /* fetchAssessment, passAssessment, */ setError } from "./recaptchaAssessment.js";
+import { fetchAssessment, passAssessment, setError } from "./recaptchaAssessment.js";
 import { getHubspotCookie } from "./utils.js";
 
 // Contact Form submission
@@ -8,11 +8,9 @@ const errorEl = 'contact-error';
 
 form?.addEventListener('submit', async (event) => {
   event.preventDefault();
-  
-  // TODO: Restore the reCAPTCHA implementation
 
   // Get reCAPTCHA token and form action.
-/*   const contactBttn = document.getElementById('contact-bttn');
+  const contactBttn = document.getElementById('contact-bttn');
   const siteKey = contactBttn.dataset.sitekey;
   const action = contactBttn.dataset.action;
 
@@ -34,7 +32,7 @@ form?.addEventListener('submit', async (event) => {
   } catch (error) {
     setError(form, errorEl)
     return
-  } */
+  }
 
   // If the assessment returns a passing score, send the form data.
   const formData = new FormData(form);

--- a/static/js/newsletterForm.js
+++ b/static/js/newsletterForm.js
@@ -10,9 +10,9 @@ newsletterForm?.addEventListener('submit', async (event) => {
   event.preventDefault();
 
   // Get reCAPTCHA token and form action.
-  const contactBttn = document.getElementById('newsletter-bttn');
-  const siteKey = contactBttn.dataset.sitekey;
-  const action = contactBttn.dataset.action;
+  const newsletterBttn = document.getElementById('newsletter-bttn');
+  const siteKey = newsletterBttn.dataset.sitekey;
+  const action = newsletterBttn.dataset.action;
 
   // Create an assessment and return an error if the form submission appears to be spam or if some other error
   // occurs while fetching the data.

--- a/static/js/newsletterForm.js
+++ b/static/js/newsletterForm.js
@@ -1,4 +1,4 @@
-import { setError } from "./recaptchaAssessment.js";
+import { fetchAssessment, passAssessment, setError } from "./recaptchaAssessment.js";
 import { getHubspotCookie } from "./utils.js";
 
 //  newsletter form submission
@@ -6,8 +6,35 @@ const newsletterForm = document.getElementById('newsletterForm');
 const formID = document.getElementById('newsletterFormID');
 const errorEl = 'newsletter-error';
 
-newsletterForm?.addEventListener('submit', (event) => {
+newsletterForm?.addEventListener('submit', async (event) => {
   event.preventDefault();
+
+  // Get reCAPTCHA token and form action.
+  const contactBttn = document.getElementById('newsletter-bttn');
+  const siteKey = contactBttn.dataset.sitekey;
+  const action = contactBttn.dataset.action;
+
+  // Create an assessment and return an error if the form submission appears to be spam or if some other error
+  // occurs while fetching the data.
+  try {
+    const assessment = await fetchAssessment(siteKey, action);
+
+    if (!assessment) {
+      setError(newsletterForm, errorEl);
+      return;
+    }
+
+    // If the risk analysis score is less than 0.5, do not send the form and display an error.
+    if (!passAssessment(assessment)) {
+      setError(newsletterForm, errorEl)
+      return
+    }
+  } catch (error) {
+    setError(newsletterForm, errorEl)
+    return
+  }
+
+  // If the assessment returns a passing score, send the form data.
   const formData = new FormData(newsletterForm);
   const data = Object.fromEntries(formData);
 
@@ -24,7 +51,7 @@ newsletterForm?.addEventListener('submit', (event) => {
 
   // Get the tracking cookie.
   const hutk = getHubspotCookie();
-  
+
   // Verify the cookie exists before adding it to the data object. If it exists, send the conversion page details. 
   // HubSpot will return a 400 if the hutk isn't included with the page URI and page name.
   if (hutk) {

--- a/static/js/recaptchaAssessment.js
+++ b/static/js/recaptchaAssessment.js
@@ -44,11 +44,10 @@ function fetchRecaptchaToken(key, action) {
 // Check if the assessment score is greater than 0.5.  There is a high probability that the request is spam if it is not.
 export function passAssessment(assessment) {
   if (!assessment) {
-    setError(form, errorEl);
-    return;
+    return false;
   };
 
-  return assessment?.riskAnalysis?.score < 0.5;
+  return assessment?.riskAnalysis?.score > 0.5;
 };
 
 // Display error message if form submission fails.


### PR DESCRIPTION
This PR enables reCAPTCHA assessments for the contact and newsletter forms. It also fixes a bug that caused an error to return though a form submission was marked as safe.