### PR TITLE
Remove custom figure shortcode

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,3 +1,0 @@
-<div class="items-center my-3">
-  <img src='{{ .Get "src" | absURL }}' alt='{{ .Get "alt" }}' class="m-auto h-[300px]" />
-</div>


### PR DESCRIPTION
This PR removes a custom shortcode that was overriding Hugo's figure shortcode. The change will improve the appearance of the Rotational and NVDIA logos in @eschmier recent blog post.

Note: Only 2 other blog posts currently use the figure shortcode. Both were published in 2023 and the images in both appear fine. The other files using the shortcode that has been deleted were about Ensign and the code has been commented out. I can create a story to delete all Ensign pages in the future.

Acceptance Criteria:
https://www.awesomescreenshot.com/video/49866874?key=589f8865e5265e36dbecd09075dbc822

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: deletes a small template override so rendering falls back to Hugo’s built-in `figure`; impact is limited to pages that use the `{{< figure >}}` shortcode and may alter image sizing/styling.
> 
> **Overview**
> Removes the custom `layouts/shortcodes/figure.html` override, causing `{{< figure >}}` usages to render with Hugo’s default shortcode instead of the site-specific wrapper and fixed-height image styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf03ca5390e95a43242029725bfd02ccd47e952d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->