### PR TITLE
Change blog post draft status

### DIFF
--- a/content/en/blog/2026-03-24-prompt-injection-jailbreaking-ai-risk.md
+++ b/content/en/blog/2026-03-24-prompt-injection-jailbreaking-ai-risk.md
@@ -2,7 +2,7 @@
 title: "Prompt Injection, Jailbreaking, and the Risk Every AI Deployment Inherits"
 slug: "prompt-injection-jailbreaking-ai-risk"
 date: "2026-03-24T09:00:00-05:00"
-draft: true
+draft: false
 image: img/blog/2026-03-24-prompt-injection-jailbreaking-ai-risk/otter-guardian.png
 photo_credit: "Image generated using GPT-5"
 authors: ['Edwin Schmierer']


### PR DESCRIPTION
Changes draft status to publish blog post.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: flips a single blog post frontmatter flag from `draft: true` to `draft: false`, affecting only site content visibility.
> 
> **Overview**
> Publishes the blog post `2026-03-24-prompt-injection-jailbreaking-ai-risk.md` by changing its frontmatter from **draft** to **published** (`draft: false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfb21b6100d871733cdae5ea2b5cf900de57879e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->