### PR TITLE
Align blog headline text

### DIFF
--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -12,7 +12,7 @@
               {{ end }}
     </a>
     <div class="px-4 pt-4">
-        <ul class="flex flex-wrap">
+        <ul class="flex flex-wrap h-10">
           {{ range $key, $value := .Params.tags }}
             <li class="text-base font-bold text-[#1D65A6]">
                 <a href="/tags/{{ $value | urlize }}">{{ $value }}</a>{{ if ne $key (sub ( len $.Params.tags) 1) }},&nbsp; {{ else }}{{ end }}
@@ -24,7 +24,7 @@
                 <a href="{{ .Permalink}}" class="block">{{ .Title }}</a>
             </h3>
             <div class="mb-4">
-                <p class="my-4 sm:mt-auto">
+                <p class="my-4">
                     {{ .Summary | markdownify | truncate 240 }}
                 </p>
             </div>


### PR DESCRIPTION
Scope of Changes:
This PR sets a height on the blog tags container to fix an issue that made the blog intro text appear misaligned. 

Acceptance Criteria:
https://www.awesomescreenshot.com/video/52714349?key=90a19c18cd80a4b87ed6c39ea4f05dab